### PR TITLE
feat(monorepos): Add BUILDKITE_ANALYTICS_LOCATION_PREFIX var

### DIFF
--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -98,7 +98,7 @@ class JestBuildkiteAnalyticsReporter {
   }
 
   prefixTestPath(testFilePath) {
-    const prefix = this._testEnv.locationPrefix
+    const prefix = this._testEnv.location_prefix
     return prefix ? path.join(prefix, testFilePath) : testFilePath
   }
 

--- a/util/ci.js
+++ b/util/ci.js
@@ -43,6 +43,7 @@ class CI {
       "job_id": process.env.BUILDKITE_ANALYTICS_JOB_ID,
       "message": process.env.BUILDKITE_ANALYTICS_MESSAGE,
       "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
+      "locationPrefix": process.env.BUILDKITE_ANALYTICS_LOCATION_PREFIX,
       "version": version,
       "collector": `js-${name}`,
     })

--- a/util/ci.js
+++ b/util/ci.js
@@ -43,7 +43,7 @@ class CI {
       "job_id": process.env.BUILDKITE_ANALYTICS_JOB_ID,
       "message": process.env.BUILDKITE_ANALYTICS_MESSAGE,
       "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
-      "locationPrefix": process.env.BUILDKITE_ANALYTICS_LOCATION_PREFIX,
+      "location_prefix": process.env.BUILDKITE_ANALYTICS_LOCATION_PREFIX,
       "version": version,
       "collector": `js-${name}`,
     })

--- a/util/ci.test.js
+++ b/util/ci.test.js
@@ -49,4 +49,11 @@ describe('CI.env', () => {
 
     expect(ci.env().ci).toEqual('buildkite')
   })
+
+  test('sets location_prefix based on BUILDKITE_ANALYTICS_LOCATION_PREFIX', () => {
+    process.env.BUILDKITE_ANALYTICS_LOCATION_PREFIX = 'true'
+    ci = new CI()
+
+    expect(ci.env().location_prefix).toEqual('true')
+  })
 });


### PR DESCRIPTION
## Description

This adds the ability to set a `BUILDKITE_ANALYTICS_LOCATION_PREFIX` environment variable that will prefix all test paths with the given path. This is especially useful when using the test collector in a monorepo setting, which has multiple packages being tested in tandem as separate CI builds.

## Problem

These two tests are actually from two different CI build pipelines, and reference the relative path within each package. 

<img width="1350" alt="image" src="https://user-images.githubusercontent.com/187963/172050875-0ef371cc-bd08-4a05-9467-753038b0c710.png">

This isn't particularly useful, as the actual package paths for each are, respectively:
* `packages/app/src/__tests__/storyshots.test.ts:46`
* `packages/user-service/src/__tests__/services/user-service.test.ts:125`

## Solution

In the top example, I'd be able to fix this by setting the `BUILDKITE_ANALYTICS_LOCATION_PREFIX` env var for each pipeline as, respectively:

* `BUILDKITE_ANALYTICS_LOCATION_PREFIX="packages/app"`
* `BUILDKITE_ANALYTICS_LOCATION_PREFIX="packages/user-service"`

This would result in the following. much more useful output:

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/187963/172051025-1d83354c-7eed-4ca0-8213-5f0d44ebc69c.png">


## Note

This moves the `new CI` call up as a class property `this._testEnv`, which is used in both `onTestResult` and `uploadTestResults`.