### PR TITLE
Jasmine reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
     ### Jasmine
 
-    [Add the builkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
+    [Add the buildkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
 
     ```js
       // SpecHelper.js

--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
 ## 👉 Installing
 
-### Jest
-
 1) [Create a test suite](https://buildkite.com/docs/test-analytics), and copy the API token that it gives you.
 
-1) Add the [`buildkite-test-collector` package](https://www.npmjs.com/package/buildkite-test-collector):
+2) Add the [`buildkite-test-collector` package](https://www.npmjs.com/package/buildkite-test-collector):
 
     ```bash
     # If you use npm:
@@ -22,7 +20,11 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
     yarn add --dev buildkite-test-collector
     ```
 
-2) Update your [Jest configuration](https://jestjs.io/docs/configuration):<br>
+3) Add the buildkite test collector to your testing framework:
+
+    ### Jest
+
+    Update your [Jest configuration](https://jestjs.io/docs/configuration):<br>
 
     ```js
       // jest.config.js
@@ -37,13 +39,25 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
       testLocationInResults: true
     ```
 
-3) Run your tests locally:<br>
+    ### Jasmine
+
+    [Add the builkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
+
+    ```js
+      // SpecHelper.js
+      var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
+      var buildkiteReporter = new BuildkiteReporter();
+
+      jasmine.getEnv().addReporter(buildkiteReporter);
+    ```
+
+4) Run your tests locally:<br>
 
     ```js
     env BUILDKITE_ANALYTICS_TOKEN=xyz npm test
     ```
 
-4) Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
+5) Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
 
     ```bash
     git checkout -b add-bk-test-analytics

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -45,6 +45,8 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[1].result", "failed")
       expect(json).toHaveProperty("data[1].failure_reason")
       expect(json.data[1].failure_reason).toMatch('Expected 41 to be 42.')
+      expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
+      expect(json).toHaveProperty("data[1].failure_expanded[0].stack")
 
       done()
     }, 10000) // 10s timeout

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -37,7 +37,6 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[0].file_name", "spec/example.spec.js")
       expect(json).toHaveProperty("data[0].result", 'passed')
 
-      // expect(json).toHaveProperty("data[1].scope", "sum")
       expect(json).toHaveProperty("data[1].name", "40 + 1 equal 42")
       expect(json).toHaveProperty("data[1].identifier", "sum 40 + 1 equal 42")
       expect(json).toHaveProperty("data[1].location", "spec/example.spec.js:13")

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -44,8 +44,9 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[1].result", "failed")
       expect(json).toHaveProperty("data[1].failure_reason")
       expect(json.data[1].failure_reason).toMatch('Expected 41 to be 42.')
-      expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
-      expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
+      expect(json).toHaveProperty("data[1].failure_expanded[0].expanded[0]", "matcherName: toBe")
+      expect(json).toHaveProperty("data[1].failure_expanded[0].expanded[1]", "message: Expected 41 to be 42.")
+      expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace[0]", "    at <Jasmine>")
 
       done()
     }, 10000) // 10s timeout

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -1,0 +1,71 @@
+// Does an end-to-end test of the Jest example, using the debug output from the
+// reporter, and verifying the JSON
+
+const { exec } = require('child_process');
+const { hasUncaughtExceptionCaptureCallback } = require('process');
+const path = require('path');
+
+describe('examples/jasmine', () => {
+  const cwd = path.join(__dirname, "../examples/jasmine")
+  const env = {
+    ...process.env,
+    BUILDKITE_ANALYTICS_TOKEN: "xyz",
+    BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
+  }
+
+  test('it posts the correct JSON', (done) => {
+    exec('npm test', { cwd, env }, (error, stdout, stderr) => {
+      expect(stdout).toMatch(/Posting to Test Analytics: ({.*})/m);
+
+      const jsonMatch = stdout.match(/Posting to Test Analytics: ({.*})/m)
+      const json = JSON.parse(jsonMatch[1])
+
+      // Uncomment to view the JSON
+      // console.log(json)
+
+      expect(json).toHaveProperty("format", "json")
+
+      expect(json).toHaveProperty("run_env.ci")
+      expect(json).toHaveProperty("run_env.debug", 'true')
+      expect(json).toHaveProperty("run_env.key")
+      expect(json).toHaveProperty("run_env.version")
+      expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+
+      expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
+      expect(json).toHaveProperty("data[0].identifier", '1 + 2 to equal 3')
+      expect(json).toHaveProperty("data[0].location", "spec/example.spec.js:7")
+      expect(json).toHaveProperty("data[0].file_name", "spec/example.spec.js")
+      expect(json).toHaveProperty("data[0].result", 'passed')
+
+      // expect(json).toHaveProperty("data[1].scope", "sum")
+      expect(json).toHaveProperty("data[1].name", "40 + 1 equal 42")
+      expect(json).toHaveProperty("data[1].identifier", "sum 40 + 1 equal 42")
+      expect(json).toHaveProperty("data[1].location", "spec/example.spec.js:13")
+      expect(json).toHaveProperty("data[1].file_name", "spec/example.spec.js")
+      expect(json).toHaveProperty("data[1].result", "failed")
+      expect(json).toHaveProperty("data[1].failure_reason")
+      expect(json.data[1].failure_reason).toMatch('Expected 41 to be 42.')
+
+      done()
+    }, 10000) // 10s timeout
+  })
+
+  test('it supports test location prefixes for monorepos', (done) => {
+    exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
+      expect(stdout).toMatch(/Posting to Test Analytics: ({.*})/m);
+
+      const jsonMatch = stdout.match(/Posting to Test Analytics: ({.*})/m)
+      const json = JSON.parse(jsonMatch[1])
+
+      // Uncomment to view the JSON
+      // console.log(json)
+
+      expect(json).toHaveProperty("run_env.location_prefix", "some-sub-dir/")
+
+      expect(json).toHaveProperty("data[0].location", "some-sub-dir/spec/example.spec.js:7")
+      expect(json).toHaveProperty("data[1].location", "some-sub-dir/spec/example.spec.js:13")
+
+      done()
+    }, 10000) // 10s timeout
+  })
+})

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -46,7 +46,7 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[1].failure_reason")
       expect(json.data[1].failure_reason).toMatch('Expected 41 to be 42.')
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
-      expect(json).toHaveProperty("data[1].failure_expanded[0].stack")
+      expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
 
       done()
     }, 10000) // 10s timeout

--- a/examples/jasmine/package.json
+++ b/examples/jasmine/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "buildkite-test-collector-jasmine-example",
+  "scripts": {
+    "test": "jasmine"
+  },
+  "devDependencies": {
+    "buildkite-test-collector": "file:../..",
+    "jasmine": "^4.2.1"
+  }
+}

--- a/examples/jasmine/spec/example.spec.js
+++ b/examples/jasmine/spec/example.spec.js
@@ -1,0 +1,16 @@
+var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
+var buildkiteReporter = new BuildkiteReporter();
+
+jasmine.getEnv().addReporter(buildkiteReporter);
+
+// No scope
+it('1 + 2 to equal 3', () => {
+  expect(1 + 2).toBe(3);
+});
+
+// In a scope
+describe('sum', () => {
+  it('40 + 1 equal 42', () => {
+    expect(40 + 1).toBe(42);
+  });
+})

--- a/examples/jasmine/spec/support/jasmine.json
+++ b/examples/jasmine/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.?(m)js"
+  ],
+  "random": false,
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "random": true
+  }
+}

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -98,7 +98,7 @@ class JasmineBuildkiteAnalyticsReporter {
       let expandedArray = Object.keys(expanded).map((key) => {
         return `${key}: ${expanded[key]}`
       })
-      return { stack: stack.split(/\r?\n/), expanded: expandedArray } // change expanded to be an array, it may work like the example!
+      return { backtrace: stack.split(/\r?\n/), expanded: expandedArray } // change expanded to be an array, it may work like the example!
     })
   }
 }

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -57,7 +57,7 @@ class JasmineBuildkiteAnalyticsReporter {
       'file_name': prefixedTestPath,
       'result': this.analyticsResult(result),
       'failure_reason': (result.failedExpectations[0] || {}).message,
-      'failure_expanded': result.failedExpectations,
+      'failure_expanded': this.failureExpanded(result),
       'history': {
         'section': 'top',
         'start_at': result.properties.startAt,
@@ -90,6 +90,16 @@ class JasmineBuildkiteAnalyticsReporter {
       failed: 'failed',
       disabled: 'skipped'
     }[testResult.status]
+  }
+
+  failureExpanded(testResult) {
+    return testResult.failedExpectations.map((failure) => {
+      let {stack, ...expanded} = failure
+      let expandedArray = Object.keys(expanded).map((key) => {
+        return `${key}: ${expanded[key]}`
+      })
+      return { stack: stack.split(/\r?\n/), expanded: expandedArray } // change expanded to be an array, it may work like the example!
+    })
   }
 }
 

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -1,16 +1,21 @@
-let filenames = {}
+let testLocations = {}
 
 const findLocation = () => {
   const fileRegexp = /at.* \({0,1}(.*|\w*):(.*):\d*/
   const trace = (new Error()).stack.split(/\n/)
   const location = (trace.filter((line) => line.match(/spec\.js/gi))[0] || '')
+  const locationArray = location.match(fileRegexp) || []
+  return {
+    filename: locationArray[1],
+    line: locationArray[2]
+  }
   return (location.match(fileRegexp) || [])[1]
 }
 
 const itFactory = (it) => {
   return function (description, fn, timeout) {
     const spec = it.apply(this, arguments)
-    filenames[spec.id] = findLocation()
+    testLocations[spec.id] = findLocation()
     return spec
   }
 }
@@ -24,8 +29,8 @@ class JasmineBuildkiteAnalyticsReporter {
   }
 
   specDone(result) {
-    let filename = filenames[result.id]
-    // console.log('result', result)
+    result.location = testLocations[result.id]
+    console.log('result', result)
   }
 }
 

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -23,8 +23,10 @@ const itFactory = (it) => {
   }
 }
 
-// Ovveride jasmine's it() function to retrieve the spec filename
+// Ovveride jasmine's it(), fit() and xit() functions to retrieve the spec filename
 jasmine.getEnv().it = itFactory(jasmine.getEnv().it);
+jasmine.getEnv().xit = itFactory(jasmine.getEnv().xit);
+jasmine.getEnv().fit = itFactory(jasmine.getEnv().fit);
 
 class JasmineBuildkiteAnalyticsReporter {
   constructor() {
@@ -57,8 +59,8 @@ class JasmineBuildkiteAnalyticsReporter {
     })
   }
 
-  suiteDone(result, done) {
-    uploadTestResults(this._testEnv, this._testResults)
+  jasmineDone(result, done) {
+    return uploadTestResults(this._testEnv, this._testResults, done)
   }
 
   analyticsResult(testResult) {

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -1,0 +1,32 @@
+let filenames = {}
+
+const findLocation = () => {
+  const fileRegexp = /at.* \({0,1}(.*|\w*):(.*):\d*/
+  const trace = (new Error()).stack.split(/\n/)
+  const location = (trace.filter((line) => line.match(/spec\.js/gi))[0] || '')
+  return (location.match(fileRegexp) || [])[1]
+}
+
+const itFactory = (it) => {
+  return function (description, fn, timeout) {
+    const spec = it.apply(this, arguments)
+    filenames[spec.id] = findLocation()
+    return spec
+  }
+}
+
+// Ovveride jasmine's it() function to retrieve the spec filename
+jasmine.getEnv().it = itFactory(jasmine.getEnv().it);
+
+class JasmineBuildkiteAnalyticsReporter {
+  specStarted(result) {
+    // console.log('result', result)
+  }
+
+  specDone(result) {
+    let filename = filenames[result.id]
+    // console.log('result', result)
+  }
+}
+
+module.exports = JasmineBuildkiteAnalyticsReporter

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -3,6 +3,8 @@ const CI = require('../util/ci')
 const uploadTestResults = require('../util/uploadTestResults')
 let testLocations = {}
 
+// Jasmine does not provide the filename when reporting on test cases
+// We can retrieve it by looking at the stack and extracting the last spec file we see.
 const findLocation = () => {
   const fileRegexp = /at.* \({0,1}(.*|\w*):(.*):\d*/
   const trace = (new Error()).stack.split(/\n/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,26 @@
       "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
-        "examples/jest"
+        "examples/jest",
+        "examples/jasmine"
       ],
       "dependencies": {
         "axios": "^0.26.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "jasmine": "^4.2.1",
         "jest": "^28.1.0"
       },
       "engines": {
         "npm": ">=7.0.0"
+      }
+    },
+    "examples/jasmine": {
+      "name": "buildkite-test-collector-jasmine-example",
+      "devDependencies": {
+        "buildkite-test-collector": "file:../..",
+        "jasmine": "^4.2.1"
       }
     },
     "examples/jest": {
@@ -1300,6 +1309,10 @@
       "resolved": "",
       "link": true
     },
+    "node_modules/buildkite-test-collector-jasmine-example": {
+      "resolved": "examples/jasmine",
+      "link": true
+    },
     "node_modules/buildkite-test-collector-jest-example": {
       "resolved": "examples/jest",
       "link": true
@@ -1978,6 +1991,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jasmine": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.2.1.tgz",
+      "integrity": "sha512-LNZEKcScnjPRj5J92I1P515bxTvaHMRAERTyCoaGnWr87eOT6zv+b3M+kxKdH/06Gz4TnnXyHbXLiPtMHZ0ncw==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.2.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
+      }
+    },
+    "node_modules/jasmine-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
+      "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "28.1.0",
@@ -4435,7 +4467,9 @@
       "version": "file:",
       "requires": {
         "axios": "^0.26.1",
+        "buildkite-test-collector-jasmine-example": "file:examples/jasmine",
         "buildkite-test-collector-jest-example": "file:examples/jest",
+        "jasmine": "^4.2.1",
         "jest": "^28.1.0",
         "uuid": "^8.3.2"
       },
@@ -5440,6 +5474,13 @@
           "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
           "dev": true
         },
+        "buildkite-test-collector-jasmine-example": {
+          "version": "file:examples/jasmine",
+          "requires": {
+            "buildkite-test-collector": "file:../..",
+            "jasmine": "^4.2.1"
+          }
+        },
         "buildkite-test-collector-jest-example": {
           "version": "file:examples/jest",
           "requires": {
@@ -5933,6 +5974,22 @@
             "html-escaper": "^2.0.0",
             "istanbul-lib-report": "^3.0.0"
           }
+        },
+        "jasmine": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.2.1.tgz",
+          "integrity": "sha512-LNZEKcScnjPRj5J92I1P515bxTvaHMRAERTyCoaGnWr87eOT6zv+b3M+kxKdH/06Gz4TnnXyHbXLiPtMHZ0ncw==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.6",
+            "jasmine-core": "^4.2.0"
+          }
+        },
+        "jasmine-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
+          "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
+          "dev": true
         },
         "jest": {
           "version": "28.1.0",
@@ -7021,6 +7078,13 @@
         }
       }
     },
+    "buildkite-test-collector-jasmine-example": {
+      "version": "file:examples/jasmine",
+      "requires": {
+        "buildkite-test-collector": "file:../..",
+        "jasmine": "^4.2.1"
+      }
+    },
     "buildkite-test-collector-jest-example": {
       "version": "file:examples/jest",
       "requires": {
@@ -7514,6 +7578,22 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "jasmine": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.2.1.tgz",
+      "integrity": "sha512-LNZEKcScnjPRj5J92I1P515bxTvaHMRAERTyCoaGnWr87eOT6zv+b3M+kxKdH/06Gz4TnnXyHbXLiPtMHZ0ncw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.6",
+        "jasmine-core": "^4.2.0"
+      }
+    },
+    "jasmine-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
+      "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
+      "dev": true
     },
     "jest": {
       "version": "28.1.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "jasmine": "^4.2.1",
     "jest": "^28.1.0"
   },
   "workspaces": [
-    "examples/jest"
+    "examples/jest",
+    "examples/jasmine"
   ],
   "scripts": {
     "test": "jest",

--- a/util/debug.js
+++ b/util/debug.js
@@ -1,0 +1,7 @@
+const debug = (text) => {
+  if (process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED === "true") {
+    console.log(text)
+  }
+}
+
+module.exports = debug

--- a/util/paths.js
+++ b/util/paths.js
@@ -1,0 +1,21 @@
+const path = require('path')
+
+class Paths {
+  constructor(config, prefix) {
+    this.config = config
+    this.prefix = prefix
+  }
+
+  relativeTestFilePath(testFilePath) {
+    // Based upon https://github.com/facebook/jest/blob/49393d01cdda7dfe75718aa1a6586210fa197c72/packages/jest-reporters/src/relativePath.ts#L11
+    const dir = this.config.cwd || this.config.rootDir
+    return path.relative(dir, testFilePath)
+  }
+
+  prefixTestPath(testFilePath) {
+    const relativePath = this.relativeTestFilePath(testFilePath)
+    return this.prefix ? path.join(this.prefix, relativePath) : relativePath
+  }
+}
+
+module.exports = Paths

--- a/util/paths.test.js
+++ b/util/paths.test.js
@@ -1,0 +1,23 @@
+const Paths = require("./paths")
+const process = require("process")
+
+describe("Paths#prefixTestPath", () => {
+  it("returns the relative path when provided an absolute path", () => {
+    const testPath = '/path/to/codebase/app/tests/best.test.js'
+    const cwd = '/path/to/codebase/app'
+
+    const paths = new Paths({ cwd: cwd})
+    expect(paths.prefixTestPath(testPath)).toEqual('tests/best.test.js')
+  })
+
+  describe("when a prefix is provided", () => {
+    it("adds the prefix to the start of the test path", () => {
+      const testPath = '/path/to/codebase/app/tests/best.test.js'
+      const cwd = '/path/to/codebase/app'
+      const prefix = 'happy-library'
+  
+      const paths = new Paths({ cwd: cwd }, prefix)
+      expect(paths.prefixTestPath(testPath)).toEqual('happy-library/tests/best.test.js')
+    })
+  })
+})

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -2,7 +2,7 @@ const debug = require('../util/debug')
 const axios = require('axios')
 const CHUNK_SIZE = 5000
 
-const uploadTestResults = (env, results) => {
+const uploadTestResults = (env, results, done) => {
   const buildkiteAnalyticsToken = process.env.BUILDKITE_ANALYTICS_TOKEN
   let data
 
@@ -30,6 +30,7 @@ const uploadTestResults = (env, results) => {
     axios.post('https://analytics-api.buildkite.com/v1/uploads', data, config)
     .then(function (response) {
       debug(`Test Analytics success response: ${JSON.stringify(response.data)}`)
+      if(done !== undefined) { return done() }
     })
     .catch(function (error) {
       if (error.response) {
@@ -37,6 +38,7 @@ const uploadTestResults = (env, results) => {
       } else {
         console.error(`Test Analytics error: ${error.message}`)
       }
+      if(done !== undefined) { return done() }
     })
   }
 }

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -22,7 +22,7 @@ const uploadTestResults = (env, results, done) => {
     data = {
       'format': 'json',
       'run_env': env,
-      "data": results.slice(i, i + 5000),
+      "data": results.slice(i, i + CHUNK_SIZE),
     }
 
     debug(`Posting to Test Analytics: ${JSON.stringify(data)}`)

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -1,0 +1,44 @@
+const debug = require('../util/debug')
+const axios = require('axios')
+const CHUNK_SIZE = 5000
+
+const uploadTestResults = (env, results) => {
+  const buildkiteAnalyticsToken = process.env.BUILDKITE_ANALYTICS_TOKEN
+  let data
+
+  if (!buildkiteAnalyticsToken) {
+    console.error('Missing BUILDKITE_ANALYTICS_TOKEN')
+    return
+  }
+
+  const config = {
+    headers: {
+      'Authorization': `Token token="${buildkiteAnalyticsToken}"`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  for (let i=0; i < results.length; i += CHUNK_SIZE) {
+    data = {
+      'format': 'json',
+      'run_env': env,
+      "data": results.slice(i, i + 5000),
+    }
+
+    debug(`Posting to Test Analytics: ${JSON.stringify(data)}`)
+
+    axios.post('https://analytics-api.buildkite.com/v1/uploads', data, config)
+    .then(function (response) {
+      debug(`Test Analytics success response: ${JSON.stringify(response.data)}`)
+    })
+    .catch(function (error) {
+      if (error.response) {
+        console.error(`Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+      } else {
+        console.error(`Test Analytics error: ${error.message}`)
+      }
+    })
+  }
+}
+
+module.exports = uploadTestResults

--- a/util/uploadTestResults.test.js
+++ b/util/uploadTestResults.test.js
@@ -1,4 +1,5 @@
-const JestBuildkiteAnalyticsReporter = require('./reporter');
+const uploadTestResults = require('./uploadTestResults')
+const CI = require('../util/ci')
 const axios = require('axios');
 const { version } = require('../package.json')
 
@@ -25,8 +26,7 @@ describe('with no token', () => {
   })
 
   it('prints a console message and returns', () => {
-    const reporter = new JestBuildkiteAnalyticsReporter({}, {})
-    reporter.onRunComplete({}, {})
+    uploadTestResults({}, [])
 
     expect(console.error).toBeCalledTimes(1)
     expect(console.error).toHaveBeenLastCalledWith('Missing BUILDKITE_ANALYTICS_TOKEN')
@@ -39,8 +39,7 @@ describe('with empty token', () => {
   })
 
   it('prints a console message and returns', () => {
-    const reporter = new JestBuildkiteAnalyticsReporter({}, {})
-    reporter.onRunComplete({}, {})
+    uploadTestResults({}, [])
 
     expect(console.error).toBeCalledTimes(1)
     expect(console.error).toHaveBeenLastCalledWith('Missing BUILDKITE_ANALYTICS_TOKEN')
@@ -57,9 +56,7 @@ describe('with token "abc"', () => {
     it('posts a result', () => {
       axios.post.mockResolvedValue({ data: "Success" })
 
-      const reporter = new JestBuildkiteAnalyticsReporter({}, {})
-      reporter._testResults = ['result']
-      reporter.onRunComplete({}, {})
+      uploadTestResults(new CI().env(), ['result'])
 
       expect(axios.post.mock.calls[0]).toEqual([
         "https://analytics-api.buildkite.com/v1/uploads",
@@ -85,9 +82,7 @@ describe('with token "abc"', () => {
     it('does a single posts if < 5000', () => {
       axios.post.mockResolvedValue({ data: "Success" });
       
-      const reporter = new JestBuildkiteAnalyticsReporter({}, {})
-      reporter._testResults = Array(4999).fill('result')
-      reporter.onRunComplete({}, {})
+      uploadTestResults({}, Array(4999).fill('result'))
 
       expect(axios.post.mock.calls.length).toBe(1)
     })
@@ -95,9 +90,7 @@ describe('with token "abc"', () => {
     it('posts 5000 results at a time', () => {
       axios.post.mockResolvedValue({ data: "Success" })
       
-      const reporter = new JestBuildkiteAnalyticsReporter({}, {})
-      reporter._testResults = Array(12000).fill('result')
-      reporter.onRunComplete({}, {})
+      uploadTestResults({}, Array(12000).fill('result'))
 
       expect(axios.post.mock.calls.length).toBe(3)
     })


### PR DESCRIPTION
This was pretty straightforward, the only tricky thing in Jasmine is that it doesn't provide the filename of specs in the reporter, but using the example from here: https://github.com/agirorn/jasmine-slow-reporter we're able to get it by inspecting the stack and looking for the first spec file.


#### TODO:
- [x] Add automated testing
- [x] Fix error message not expanding on the UI
- [x] Confirm each status is correctly sent
- [x] Confirm the result data is correct
- [x] Confirm the timing data is correct
- [x] Correctly wait for `specDone` by returning a promise, or using async/await for `uploadTestResults`
- [x] Update README with instructions to add a jasmine reporter