### PR TITLE
Jasmine HTTP instrumentation

### DIFF
--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -48,6 +48,12 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded[1]", "message: Expected 41 to be 42.")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace[0]", "    at <Jasmine>")
 
+      expect(json).toHaveProperty("data[2].history.section", "top")
+      expect(json).toHaveProperty("data[2].history.children[0].section", "http")
+      expect(json).toHaveProperty("data[2].history.children[0].detail.lib", "http")
+      expect(json).toHaveProperty("data[2].history.children[0].detail.method", "GET")
+      expect(json).toHaveProperty("data[2].history.children[0].detail.url", "buildkite.com/")
+
       done()
     }, 10000) // 10s timeout
   })

--- a/examples/jasmine/spec/example.spec.js
+++ b/examples/jasmine/spec/example.spec.js
@@ -1,6 +1,6 @@
+let axios = require('axios')
 var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
 var buildkiteReporter = new BuildkiteReporter();
-
 jasmine.getEnv().addReporter(buildkiteReporter);
 
 // No scope
@@ -13,4 +13,9 @@ describe('sum', () => {
   it('40 + 1 equal 42', () => {
     expect(40 + 1).toBe(42);
   });
+})
+
+// Test instrumenting a HTTP request
+it('connects to buildkite.com', async () => {
+  const response = await axios.get('https://buildkite.com/')
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       ],
       "dependencies": {
         "axios": "^0.26.1",
+        "request-spy": "^0.0.10",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -2741,6 +2742,11 @@
         "node": "*"
       }
     },
+    "node_modules/monkeypatch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/monkeypatch/-/monkeypatch-1.0.0.tgz",
+      "integrity": "sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2981,6 +2987,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/request-spy": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/request-spy/-/request-spy-0.0.10.tgz",
+      "integrity": "sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA==",
+      "dependencies": {
+        "monkeypatch": "^1.0.0"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4471,6 +4485,7 @@
         "buildkite-test-collector-jest-example": "file:examples/jest",
         "jasmine": "^4.2.1",
         "jest": "^28.1.0",
+        "request-spy": "*",
         "uuid": "^8.3.2"
       },
       "dependencies": {
@@ -6546,6 +6561,11 @@
             "brace-expansion": "^1.1.7"
           }
         },
+        "monkeypatch": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/monkeypatch/-/monkeypatch-1.0.0.tgz",
+          "integrity": "sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w=="
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6725,6 +6745,14 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
           "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
           "dev": true
+        },
+        "request-spy": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/request-spy/-/request-spy-0.0.10.tgz",
+          "integrity": "sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA==",
+          "requires": {
+            "monkeypatch": "^1.0.0"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
@@ -8150,6 +8178,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "monkeypatch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/monkeypatch/-/monkeypatch-1.0.0.tgz",
+      "integrity": "sha512-6tG0IrCUUIBuAspnbdmOAd+D/AptB/ya9JLujp88NIAuFuTGdGvCKtDkc6pwNOcIJ6nKLm3FjJlaCdx8vr3r2w=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8329,6 +8362,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "request-spy": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/request-spy/-/request-spy-0.0.10.tgz",
+      "integrity": "sha512-va+4vLamK9Pwu/WJnJrQcTjCjYdIcl0KDKOKEkfvNmer4f+K+OhgbpU4DCiPyzBGnTpYXbrVLrnD8O5fS/cmKA==",
+      "requires": {
+        "monkeypatch": "^1.0.0"
+      }
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "axios": "^0.26.1",
+    "request-spy": "^0.0.10",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/util/network.js
+++ b/util/network.js
@@ -1,0 +1,16 @@
+const requestSpy = require('request-spy')
+
+class Network {
+  setup(tracer) {
+    requestSpy.spy((error, requestData) => {
+      const detail = { method: requestData.method, url: requestData.hostname + requestData.path, lib: 'http' }
+      tracer.backfill('http', requestData.requestTime, detail)
+    })
+  }
+
+  teardown() {
+    requestSpy.restore()
+  }
+}
+
+module.exports = Network

--- a/util/tracer.js
+++ b/util/tracer.js
@@ -1,0 +1,54 @@
+class Span {
+  constructor(section, startAt, endAt, detail = {}) {
+    this.section = section
+    this.startAt = startAt
+    this.endAt = endAt
+    this.detail = detail
+    this.children = []
+  }
+
+  get duration() {
+    return (this.endAt - this.startAt)
+  }
+
+  toJSON() {
+    return {
+      section: this.section,
+      start_at: this.startAt,
+      end_at: this.endAt,
+      duration: this.duration,
+      detail: this.detail,
+      children: this.children.map((child) => child.toJSON())
+    }
+  }
+}
+
+class Tracer {
+  constructor() {
+    this.top = new Span('top', performance.now() / 1000)
+    this.stack = [this.top]
+  }
+
+  finalize() {
+    if(this.stack.length != 1) {
+      throw new Error("Stack not empty")
+    }
+
+    this.top.endAt = (performance.now() / 1000)
+  }
+
+  backfill(section, duration, detail) {
+    const newEntry = new Span(section, (performance.now() - duration) / 1000, performance.now() / 1000, detail)
+    this.currentSpan().children.push(newEntry)
+  }
+
+  currentSpan() {
+    return this.stack.slice(-1)[0]
+  }
+
+  history() {
+    return this.top.toJSON()
+  }
+}
+
+module.exports = Tracer

--- a/util/tracer.test.js
+++ b/util/tracer.test.js
@@ -1,0 +1,70 @@
+const Tracer = require('./tracer');
+
+describe('Tracer()', () => {
+  test('creates a top level span', () => {
+    const tracer = new Tracer()
+
+    expect(tracer.stack.length).toEqual(1)
+  })
+
+  test('sets a start time for the top level span', () => {
+    const tracer = new Tracer()
+
+    expect(tracer.stack[0].startAt).toBeDefined()
+  })
+})
+
+describe('Tracer.finalize()', () => {
+  test('sets the duration for the span', () => {
+    const tracer = new Tracer()
+    tracer.finalize()
+
+    expect(tracer.stack[0].duration).toBeDefined()
+  })
+
+  test('throws an exception when there are multiple unfinished spans', () => {
+    const tracer = new Tracer()
+    tracer.stack.push({})
+
+    expect(tracer.finalize.bind(tracer)).toThrowError(/Stack not empty/)
+  })
+})
+
+describe('Tracer.backfill()', () => {
+  test('inserts new spans into the stack', () => {
+    const tracer = new Tracer()
+    tracer.backfill('http', 500, { extra: 'detail' })
+
+    expect(tracer.stack[0].children[0].section).toEqual('http')
+    expect(tracer.stack[0].children[0].detail).toEqual({extra: 'detail'})
+    expect(tracer.stack[0].children[0].duration).toBeCloseTo(0.5, 1)
+  })
+})
+
+describe('Tracer.history()', () => {
+  test('returns all of the traces', () => {
+    global.performance = { now: () => 11000 }
+
+    const tracer = new Tracer()
+    tracer.backfill('sql', 3000, { kind: 'INSERT' })
+    tracer.finalize()
+
+    expect(tracer.history()).toEqual({
+      section: 'top',
+      start_at: 11,
+      end_at: 11,
+      duration: 0,
+      detail: {},
+      children: [
+        {
+          section: 'sql',
+          start_at: 8,
+          end_at: 11,
+          duration: 3,
+          detail: { kind: 'INSERT'},
+          children: []
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
Instrument HTTP calls for the Jasmine reporter, code is taken from PR #9 

This was really straightforward in Jasmine to get working as we can easily attach a tracer and network object to each test instance and then report on it later :)

I will rebase these changes once #32 is merged