### PR TITLE
Add warning when using Jest --forceExit option

### DIFF
--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -55,8 +55,8 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[2].history.children[0].detail.url", "buildkite.com/")
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
@@ -74,6 +74,6 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("data[1].location", "some-sub-dir/spec/example.spec.js:13")
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 })

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -59,8 +59,8 @@ describe('examples/jest', () => {
         'Received: 41\n')
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
@@ -78,6 +78,6 @@ describe('examples/jest', () => {
       expect(json).toHaveProperty("data[1].location", "some-sub-dir/example.test.js:8")
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 })

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -13,6 +13,14 @@ describe('examples/jest', () => {
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 
+  test('it outputs a warning when --forceExit option is used', (done) => {
+    exec('jest --forceExit', { cwd, env }, (error, stdout, stderr) => {
+      expect(stderr).toMatch(/--forceExit could potentially terminate any ongoing processes that are attempting to send test executions to Buildkite./);
+
+      done()
+    })
+  }, 1000) // 1s timeout
+
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
       expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -49,8 +49,8 @@ describe('examples/mocha', () => {
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
@@ -68,6 +68,6 @@ describe('examples/mocha', () => {
       expect(json).toHaveProperty("data[1].location", "some-sub-dir/test.js")
 
       done()
-    }, 10000) // 10s timeout
-  })
+    })
+  }, 10000) // 10s timeout
 })

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -12,7 +12,15 @@ class JestBuildkiteAnalyticsReporter {
     this._paths = new Paths(globalConfig, this._testEnv.location_prefix)
   }
 
-  onRunStart(test) {
+  onRunStart(results, options) {
+    if (this._globalConfig.forceExit) {
+      console.warn(
+        `--forceExit could potentially terminate any ongoing processes that ` +
+        `are attempting to send test executions to Buildkite. ` +
+        `Have you considered using \`--detectOpenHandles\` to detect ` +
+        'async operations that kept running after all tests finished?',
+      );
+    }
   }
 
   onRunComplete(_test, _results) {


### PR DESCRIPTION
PIE-1002

We have documented that using the --forceExit option in Jest could
result in missing test executions as any ongoing processes to send
execution data to Buildkite could be terminated.

This commit/PR adds prints a warning whenever the --forceExit option is
being used.

Partially resolves #36

Documentation
https://buildkite.com/docs/test-analytics/javascript-collectors#troubleshooting-missing-test-executions-and-forceexit
