### PR TITLE
update javascript collector to accept token that isn't BUILDKITE_ANALYTICS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
    yarn add --dev buildkite-test-collector
    ```
 
-3. Add the buildkite test collector to your testing framework:
+3. Add the Buildkite test collector to your testing framework:
 
    ### Jest
 
@@ -53,7 +53,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
    ### Jasmine
 
-   [Add the buildkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
+   [Add the Buildkite reporter to Jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
 
    ```js
    // SpecHelper.js

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
    // Send results to Test Analytics
    reporters: [
      "default",
-     ["buildkite-test-collector/jest/reporter", { token: INSERT_TOKEN_HERE }],
+     [
+       "buildkite-test-collector/jest/reporter",
+       { token: process.env.CUSTOM_ENV_VAR },
+     ],
    ];
    ```
 
@@ -68,7 +71,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
    ```js
    // SpecHelper.js
    var buildkiteReporter = new BuildkiteReporter(undefined, {
-     token: INSERT_TOKEN_HERE,
+     token: process.env.CUSTOM_ENV_VAR,
    });
    ```
 
@@ -100,12 +103,14 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
    If you would like to pass in the API token using a custom environment variable, you can do so using the report options.
 
+   Since the reporter options are passed in as a json file, we ask you to put the environment variable name as a string value in the `config.json`, which will be retrieved using [dotenv](https://github.com/motdotla/dotenv) in the mocha reporter.
+
    ```js
      // config.json
      {
        "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
        "buildkiteTestCollectorMochaReporterReporterOptions": {
-         "token": INSERT_TOKEN_HERE
+         "token_name": "CUSTOM_ENV_VAR_NAME"
        }
      }
    ```

--- a/README.md
+++ b/README.md
@@ -8,88 +8,121 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
 ## 👉 Installing
 
-1) [Create a test suite](https://buildkite.com/docs/test-analytics), and copy the API token that it gives you.
+1. [Create a test suite](https://buildkite.com/docs/test-analytics), and copy the API token that it gives you.
 
-2) Add the [`buildkite-test-collector` package](https://www.npmjs.com/package/buildkite-test-collector):
+2. Add the [`buildkite-test-collector` package](https://www.npmjs.com/package/buildkite-test-collector):
 
-    ```bash
-    # If you use npm:
-    npm install --save-dev buildkite-test-collector
+   ```bash
+   # If you use npm:
+   npm install --save-dev buildkite-test-collector
 
-    # or, if you use yarn:
-    yarn add --dev buildkite-test-collector
-    ```
+   # or, if you use yarn:
+   yarn add --dev buildkite-test-collector
+   ```
 
-3) Add the buildkite test collector to your testing framework:
+3. Add the buildkite test collector to your testing framework:
 
-    ### Jest
+   ### Jest
 
-    Update your [Jest configuration](https://jestjs.io/docs/configuration):<br>
+   Update your [Jest configuration](https://jestjs.io/docs/configuration):<br>
 
-    ```js
-      // jest.config.js
+   ```js
+     // jest.config.js
 
-      // Send results to Test Analytics
-      reporters: [
-        'default',
-        'buildkite-test-collector/jest/reporter'
-      ],
+     // Send results to Test Analytics
+     reporters: [
+       'default',
+       'buildkite-test-collector/jest/reporter'
+     ],
 
-      // Enable column + line capture for Test Analytics
-      testLocationInResults: true
-    ```
+     // Enable column + line capture for Test Analytics
+     testLocationInResults: true
+   ```
 
-    ### Jasmine
+   If you would like to pass in the API token using a custom environment variable, you can do so using the report options.
 
-    [Add the buildkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
+   ```js
+   // jest.config.js
 
-    ```js
-      // SpecHelper.js
-      var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
-      var buildkiteReporter = new BuildkiteReporter();
+   // Send results to Test Analytics
+   reporters: [
+     "default",
+     ["buildkite-test-collector/jest/reporter", { token: INSERT_TOKEN_HERE }],
+   ];
+   ```
 
-      jasmine.getEnv().addReporter(buildkiteReporter);
-    ```
+   ### Jasmine
 
-    ### Mocha
+   [Add the buildkite reporter to jasmine](https://jasmine.github.io/setup/nodejs.html#reporters):<br>
 
-    [Install mocha-multi-reporters](https://github.com/stanleyhlng/mocha-multi-reporters) in your project:<br>
+   ```js
+   // SpecHelper.js
+   var BuildkiteReporter = require("buildkite-test-collector/jasmine/reporter");
+   var buildkiteReporter = new BuildkiteReporter();
 
-    ```
-      npm install mocha-multi-reporters --save-dev
-    ```
+   jasmine.getEnv().addReporter(buildkiteReporter);
+   ```
 
-    and configure it to run your desired reporter and the Buildkite reporter
+   If you would like to pass in the API token using a custom environment variable, you can do so using the report options.
 
-    ```js
-      // config.json
-      {
-        "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter"
-      }
-    ```
+   ```js
+   // SpecHelper.js
+   var buildkiteReporter = new BuildkiteReporter(undefined, {
+     token: INSERT_TOKEN_HERE,
+   });
+   ```
 
-    Now update your test script to use the buildkite reporter via mocha-multi-reporters:
+   ### Mocha
 
-    ```js
-      // package.json
-      "scripts": {
-        "test": "mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json"
-      },
-    ```
+   [Install mocha-multi-reporters](https://github.com/stanleyhlng/mocha-multi-reporters) in your project:<br>
 
-4) Run your tests locally:<br>
+   ```
+     npm install mocha-multi-reporters --save-dev
+   ```
 
-    ```js
-    env BUILDKITE_ANALYTICS_TOKEN=xyz npm test
-    ```
+   and configure it to run your desired reporter and the Buildkite reporter
 
-5) Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
+   ```js
+     // config.json
+     {
+       "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter"
+     }
+   ```
 
-    ```bash
-    git checkout -b add-bk-test-analytics
-    git commit -am "Add Buildkite Test Analytics"
-    git push origin add-bk-test-analytics
-    ```
+   Now update your test script to use the buildkite reporter via mocha-multi-reporters:
+
+   ```js
+     // package.json
+     "scripts": {
+       "test": "mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json"
+     },
+   ```
+
+   If you would like to pass in the API token using a custom environment variable, you can do so using the report options.
+
+   ```js
+     // config.json
+     {
+       "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
+       "buildkiteTestCollectorMochaReporterReporterOptions": {
+         "token": INSERT_TOKEN_HERE
+       }
+     }
+   ```
+
+4. Run your tests locally:<br>
+
+   ```js
+   env BUILDKITE_ANALYTICS_TOKEN=xyz npm test
+   ```
+
+5. Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
+
+   ```bash
+   git checkout -b add-bk-test-analytics
+   git commit -am "Add Buildkite Test Analytics"
+   git push origin add-bk-test-analytics
+   ```
 
 ## 📓 Notes
 

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -13,8 +13,23 @@ describe('examples/jasmine', () => {
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 
+  describe('when token is defined through reporter options', () => {
+    test('it uses the correct token', (done) => {
+      exec('npm test spec/token.spec.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="abc"')
+
+        done()
+      })
+    }, 10000)
+  })
+
   test('it posts the correct JSON', (done) => {
-    exec('npm test', { cwd, env }, (error, stdout, stderr) => {
+    exec('npm test spec/example.spec.js', { cwd, env }, (error, stdout, stderr) => {
       expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
 
       const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
@@ -59,7 +74,7 @@ describe('examples/jasmine', () => {
   }, 10000) // 10s timeout
 
   test('it supports test location prefixes for monorepos', (done) => {
-    exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
+    exec('npm test spec/example.spec.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
       expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
 
       const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -1,6 +1,7 @@
 // Does an end-to-end test of the Jest example, using the debug output from the
 // reporter, and verifying the JSON
 
+require('dotenv').config();
 const { exec } = require('child_process');
 const { hasUncaughtExceptionCaptureCallback } = require('process');
 const path = require('path');
@@ -10,6 +11,7 @@ describe('examples/jasmine', () => {
   const env = {
     ...process.env,
     BUILDKITE_ANALYTICS_TOKEN: "xyz",
+    BUILDKITE_ANALYTICS_JASMINE_TOKEN: "abc",
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -25,7 +25,22 @@ describe('examples/jasmine', () => {
 
         done()
       })
-    }, 10000)
+    }, 10000) // 10s timeout
+  })
+
+  describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
+    test('it uses the correct token', (done) => {
+      exec('npm test spec/example.spec.js', { cwd, env }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
+
+        done()
+      })
+    }, 10000) // 10s timeout
   })
 
   test('it posts the correct JSON', (done) => {

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -26,7 +26,21 @@ describe('examples/jest', () => {
         done()
       })
     }, 10000) // 10s timeout
+  })
 
+  describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
+    test('it uses the correct token', (done) => {
+      exec('npm test', { cwd, env }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
+
+        done()
+      })
+    }, 10000) // 10s timeout
   })
 
   test('it outputs a warning when --forceExit option is used', (done) => {

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -1,6 +1,6 @@
 // Does an end-to-end test of the Jest example, using the debug output from the
 // reporter, and verifying the JSON
-
+require('dotenv').config();
 const { exec } = require('child_process');
 const { hasUncaughtExceptionCaptureCallback } = require('process');
 const path = require('path');
@@ -10,6 +10,7 @@ describe('examples/jest', () => {
   const env = {
     ...process.env,
     BUILDKITE_ANALYTICS_TOKEN: "xyz",
+    BUILDKITE_ANALYTICS_JEST_TOKEN: "abc",
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -13,6 +13,22 @@ describe('examples/jest', () => {
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 
+  describe('when token is defined through reporter options', () => {
+    test('it uses the correct token', (done) => {
+      exec('jest --config token.config.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="abc"')
+
+        done()
+      })
+    }, 10000) // 10s timeout
+
+  })
+
   test('it outputs a warning when --forceExit option is used', (done) => {
     exec('jest --forceExit', { cwd, env }, (error, stdout, stderr) => {
       expect(stderr).toMatch(/--forceExit could potentially terminate any ongoing processes that are attempting to send test executions to Buildkite./);

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -13,6 +13,22 @@ describe('examples/mocha', () => {
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 
+  describe('when token is defined through reporter options', () => {
+    test('it uses the correct token', (done) => {
+      exec('mocha --reporter mocha-multi-reporters --reporter-options configFile=token-config.json',
+      { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="abc"')
+
+        done()
+      })
+    }, 10000)
+  })
+
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
       expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -26,8 +26,24 @@ describe('examples/mocha', () => {
 
         done()
       })
-    }, 10000)
+    }, 10000) // 10s timeout
   })
+
+  describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
+    test('it uses the correct token', (done) => {
+      exec('npm test', { cwd, env }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+
+        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const json = JSON.parse(jsonMatch[1])["headers"]
+
+        expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
+
+        done()
+      })
+    }, 10000) // 10s timeout
+  })
+
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -1,6 +1,6 @@
 // Does an end-to-end test of the Mocha example, using the debug output from the
 // reporter, and verifying the JSON
-
+require('dotenv').config();
 const { exec } = require('child_process');
 const { hasUncaughtExceptionCaptureCallback } = require('process');
 const path = require('path');
@@ -10,6 +10,7 @@ describe('examples/mocha', () => {
   const env = {
     ...process.env,
     BUILDKITE_ANALYTICS_TOKEN: "xyz",
+    BUILDKITE_ANALYTICS_MOCHA_TOKEN: "abc",
     BUILDKITE_ANALYTICS_DEBUG_ENABLED: "true"
   }
 

--- a/examples/jasmine/spec/token.spec.js
+++ b/examples/jasmine/spec/token.spec.js
@@ -1,0 +1,8 @@
+let axios = require('axios')
+var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
+var buildkiteReporter = new BuildkiteReporter(undefined, { token: "abc" });
+jasmine.getEnv().addReporter(buildkiteReporter);
+
+it('1 + 2 to equal 3', () => {
+  expect(1 + 2).toBe(3);
+});

--- a/examples/jasmine/spec/token.spec.js
+++ b/examples/jasmine/spec/token.spec.js
@@ -1,6 +1,5 @@
-let axios = require('axios')
 var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
-var buildkiteReporter = new BuildkiteReporter(undefined, { token: "abc" });
+var buildkiteReporter = new BuildkiteReporter(undefined, { token: process.env.BUILDKITE_ANALYTICS_JASMINE_TOKEN });
 jasmine.getEnv().addReporter(buildkiteReporter);
 
 it('1 + 2 to equal 3', () => {

--- a/examples/jest/token.config.js
+++ b/examples/jest/token.config.js
@@ -2,7 +2,7 @@ const config = {
   // Send results to Test Analytics
   reporters: [
     'default',
-    ['buildkite-test-collector/jest/reporter', { token: "abc" }]
+    ['buildkite-test-collector/jest/reporter', { token: process.env.BUILDKITE_ANALYTICS_JEST_TOKEN }]
   ],
 
   // Enable column + line capture for Test Analytics

--- a/examples/jest/token.config.js
+++ b/examples/jest/token.config.js
@@ -1,0 +1,12 @@
+const config = {
+  // Send results to Test Analytics
+  reporters: [
+    'default',
+    ['buildkite-test-collector/jest/reporter', { token: "abc" }]
+  ],
+
+  // Enable column + line capture for Test Analytics
+  testLocationInResults: true
+};
+
+module.exports = config;

--- a/examples/mocha/token-config.json
+++ b/examples/mocha/token-config.json
@@ -1,6 +1,6 @@
 {
   "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
   "buildkiteTestCollectorMochaReporterReporterOptions": {
-    "token": "abc"
+    "token_name": "BUILDKITE_ANALYTICS_MOCHA_TOKEN"
   }
 }

--- a/examples/mocha/token-config.json
+++ b/examples/mocha/token-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
+  "buildkiteTestCollectorMochaReporterReporterOptions": {
+    "token": "abc"
+  }
+}

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -37,8 +37,9 @@ jasmine.getEnv().xit = itFactory(jasmine.getEnv().xit);
 jasmine.getEnv().fit = itFactory(jasmine.getEnv().fit);
 
 class JasmineBuildkiteAnalyticsReporter {
-  constructor(config = { cwd: process.cwd() }) {
+  constructor(config = { cwd: process.cwd() }, options) {
     this.config = config
+    this._options = options
     this._testResults = []
     this._testEnv = (new CI()).env();
     this._paths = new Paths(config, this._testEnv.location_prefix)
@@ -76,7 +77,7 @@ class JasmineBuildkiteAnalyticsReporter {
   }
 
   jasmineDone(result, done) {
-    return uploadTestResults(this._testEnv, this._testResults, done)
+    return uploadTestResults(this._testEnv, this._testResults, this._options, done)
   }
 
   analyticsResult(testResult) {

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -23,8 +23,8 @@ class JestBuildkiteAnalyticsReporter {
     }
   }
 
-  onRunComplete(_test, _results) {
-    uploadTestResults(this._testEnv, this._testResults)
+  onRunComplete(_test, _results, _options) {
+    uploadTestResults(this._testEnv, this._testResults, this._options)
   }
 
   onTestStart(test) {

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -20,7 +20,8 @@ const {
 } = Runnable.constants
 
 class MochaBuildkiteAnalyticsReporter {
-  constructor(runner) {
+  constructor(runner, options) {
+    this._options = options.reporterOptions
     this._testResults = []
     this._testEnv = (new CI()).env();
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix)
@@ -66,7 +67,7 @@ class MochaBuildkiteAnalyticsReporter {
   }
 
   testRunFinished() {
-    uploadTestResults(this._testEnv, this._testResults)
+    uploadTestResults(this._testEnv, this._testResults, this._options)
   }
 
   analyticsResult(state) {

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -21,7 +21,7 @@ const {
 
 class MochaBuildkiteAnalyticsReporter {
   constructor(runner, options) {
-    this._options = options.reporterOptions
+    this._options = { token: process.env[`${options.reporterOptions.token_name}`]}
     this._testResults = []
     this._testEnv = (new CI()).env();
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "axios": "^0.26.1",
+        "dotenv": "^16.0.2",
         "request-spy": "^0.0.10",
         "uuid": "^8.3.2"
       },
@@ -1590,6 +1591,14 @@
       "dev": true,
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5028,6 +5037,7 @@
         "axios": "^0.26.1",
         "buildkite-test-collector-jasmine-example": "file:examples/jasmine",
         "buildkite-test-collector-jest-example": "file:examples/jest",
+        "dotenv": "*",
         "jasmine": "^4.2.1",
         "jest": "^28.1.0",
         "mocha": "^10.0.0",
@@ -6244,6 +6254,11 @@
           "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
           "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
           "dev": true
+        },
+        "dotenv": {
+          "version": "16.0.2",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+          "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
         },
         "electron-to-chromium": {
           "version": "1.4.140",
@@ -8208,6 +8223,11 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
       "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
       "dev": true
+    },
+    "dotenv": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
+      "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
     },
     "electron-to-chromium": {
       "version": "1.4.140",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "axios": "^0.26.1",
+    "dotenv": "^16.0.2",
     "request-spy": "^0.0.10",
     "uuid": "^8.3.2"
   },

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -2,8 +2,8 @@ const Debug = require('../util/debug')
 const axios = require('axios')
 const CHUNK_SIZE = 5000
 
-const uploadTestResults = (env, results, done) => {
-  const buildkiteAnalyticsToken = process.env.BUILDKITE_ANALYTICS_TOKEN
+const uploadTestResults = (env, results, options, done) => {
+  const buildkiteAnalyticsToken = options?.token || process.env.BUILDKITE_ANALYTICS_TOKEN
   let data
 
   if (!buildkiteAnalyticsToken) {

--- a/util/uploadTestResults.test.js
+++ b/util/uploadTestResults.test.js
@@ -46,6 +46,38 @@ describe('with empty token', () => {
   })
 })
 
+describe('with token "abc" defined in reporter options', () => {
+  beforeEach(() => {
+    process.env.BUILDKITE_ANALYTICS_KEY = 'key123';
+  })
+
+  it('posts a result', () => {
+    axios.post.mockResolvedValue({ data: "Success" })
+
+    uploadTestResults(new CI().env(), ['result'], { token: 'abc'})
+
+    expect(axios.post.mock.calls[0]).toEqual([
+      "https://analytics-api.buildkite.com/v1/uploads",
+      {
+        "data": [ "result" ],
+        "format": "json",
+        "run_env": {
+          "ci": "generic",
+          "collector": "js-buildkite-test-collector",
+          "key": "key123",
+          "version": version
+        }
+      },
+      {
+        "headers": {
+          "Authorization": "Token token=\"abc\"",
+          "Content-Type": "application/json",
+        }
+      }
+    ])
+  })
+})
+
 describe('with token "abc"', () => {
   beforeEach(() => {
     process.env.BUILDKITE_ANALYTICS_TOKEN = 'abc';
@@ -81,7 +113,7 @@ describe('with token "abc"', () => {
 
     it('does a single posts if < 5000', () => {
       axios.post.mockResolvedValue({ data: "Success" });
-      
+
       uploadTestResults({}, Array(4999).fill('result'))
 
       expect(axios.post.mock.calls.length).toBe(1)
@@ -89,7 +121,7 @@ describe('with token "abc"', () => {
 
     it('posts 5000 results at a time', () => {
       axios.post.mockResolvedValue({ data: "Success" })
-      
+
       uploadTestResults({}, Array(12000).fill('result'))
 
       expect(axios.post.mock.calls.length).toBe(3)


### PR DESCRIPTION
The [rspec collector can be configured](https://github.com/buildkite/test-collector-ruby/blob/d9fe11341e4aa470e766febee38124b644572360/lib/buildkite/test_collector.rb#L48) so you can provide the token in a way that doesn't look for the `BUILDKITE_ANALYTICS_TOKEN` environment variable.

We should do the same for the javascript collector.

This also needs to be done to support multiple suites per pipeline, since we can't have the same  `BUILDKITE_ANALYTICS_TOKEN` defined twice with different values in the same pipeline 😬