### PR TITLE
[PIE-1380] Send failure_expanded to Test Analytics

### DIFF
--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -84,11 +84,14 @@ describe('examples/jest', () => {
       expect(json).toHaveProperty("data[1].file_name", "example.test.js")
       expect(json).toHaveProperty("data[1].result", "failed")
       expect(json).toHaveProperty("data[1].failure_reason")
-      expect(json.data[1].failure_reason).toMatch('Error: expect(received).toBe(expected) // Object.is equality\n' +
-        '\n' +
-        'Expected: 42\n' +
-        'Received: 41\n')
-
+      expect(json.data[1].failure_reason).toEqual('Error: expect(received).toBe(expected) // Object.is equality')
+      
+      expect(json).toHaveProperty("data[1].failure_expanded")
+      expect(json.data[1].failure_expanded).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          expanded: expect.arrayContaining(["Expected: 42", "Received: 41"])
+        })
+      ]))
       done()
     })
   }, 10000) // 10s timeout

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -44,7 +44,7 @@ class JestBuildkiteAnalyticsReporter {
         'file_name': prefixedTestPath,
         'result': this.analyticsResult(result),
         'failure_reason': this.analyticsFailureReason(result),
-        // TODO: Add support for 'failure_expanded'
+        'failure_expanded': this.analyticsFailureExpanded(result),
         'history': {
           'section': 'top',
           'start_at': testResult.perfStats.start,
@@ -78,11 +78,23 @@ class JestBuildkiteAnalyticsReporter {
     }[testResult.status]
   }
 
+  analyticsFailureMessages(testResult) {
+    if (testResult.status !== 'failed') return []
+
+    // Strip ANSI color codes from messages and split each line
+    return testResult.failureMessages.join(' ').replace(/\u001b[^m]*?m/g,'').split("\n")
+  }
+  
   analyticsFailureReason(testResult) {
-    if (testResult.status === 'failed') {
-      // Strip ANSI color codes from messages
-      return testResult.failureMessages.join(' ').replace(/\u001b[^m]*?m/g,'')
-    }
+    return this.analyticsFailureMessages(testResult)[0]
+  }
+
+  analyticsFailureExpanded(testResult) {
+    return [
+      { 
+        expanded: this.analyticsFailureMessages(testResult).splice(1)
+      }
+    ]
   }
 }
 

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -1,6 +1,8 @@
 const Debug = require('../util/debug')
 const axios = require('axios')
+
 const CHUNK_SIZE = 5000
+const DEFAULT_BUILDKITE_ANALYTICS_URL = 'https://analytics-api.buildkite.com/v1/uploads'
 
 const uploadTestResults = (env, results, options, done) => {
   const buildkiteAnalyticsToken = options?.token || process.env.BUILDKITE_ANALYTICS_TOKEN
@@ -55,7 +57,8 @@ const uploadTestResults = (env, results, options, done) => {
       });
     }
 
-    axios.post('https://analytics-api.buildkite.com/v1/uploads', data, config)
+    const buildkiteAnalyticsUrl = process.env.BUILDKITE_ANALYTICS_URL || DEFAULT_BUILDKITE_ANALYTICS_URL
+    axios.post(buildkiteAnalyticsUrl, data, config)
     .then(function (response) {
       if(done !== undefined) { return done() }
     })


### PR DESCRIPTION
### Description

Currently, `test-collector-javascript` for Jest sends a full failure message as `failure_reason` and skips `failure_expanded`. It should send a full failure message as `failure_expanded` and send a summary as `failure_reason`.

### Context

We want to limit the length of `failure_reason` that can be stored by Test Analytics in the upcoming changes. Therefore, we need to split the failure messages into a short summary that goes into `failure_reason` and the detail that goes into `failure_expanded`

### Changes

1. `jest` reporter will now send the first line of `failureMessages` as `failureReason` and the rest of the lines as `failureExpanded` (resolves #17)
2. Test analytics API endpoint is now configurable with `BUILDKITE_ANALYTICS_URL` env (resolves #46)

### Verification

Test the integration with Test Analytics API by following these steps:
1. install dependencies `npm install`
3. go to the example directory `cd examples/jest`
4. run the example test `BUILDKITE_ANALYTICS_TOKEN=<YOUR_SUITE_TOKEN> npm test`
5. you should be able to see the results in Test Analytics

**note:**
If you want to verify against local Test Analytics, add `BUILDKITE_ANALYTICS_URL=http://analytics-api.buildkite.localhost/v1/uploads` env when running the command:
```
BUILDKITE_ANALYTICS_TOKEN=<YOUR_SUITE_TOKEN> BUILDKITE_ANALYTICS_URL=http://analytics-api.buildkite.localhost/v1/uploads npm test
```


### Deployment

Publish to NPM registry