### PR TITLE
PIE-1388 Rename env variable used to override analytics API url

### DIFF
--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -2,7 +2,7 @@ const Debug = require('../util/debug')
 const axios = require('axios')
 
 const CHUNK_SIZE = 5000
-const DEFAULT_BUILDKITE_ANALYTICS_URL = 'https://analytics-api.buildkite.com/v1/uploads'
+const DEFAULT_BUILDKITE_ANALYTICS_BASE_URL = 'https://analytics-api.buildkite.com/v1/uploads'
 
 const uploadTestResults = (env, results, options, done) => {
   const buildkiteAnalyticsToken = options?.token || process.env.BUILDKITE_ANALYTICS_TOKEN
@@ -57,7 +57,7 @@ const uploadTestResults = (env, results, options, done) => {
       });
     }
 
-    const buildkiteAnalyticsUrl = process.env.BUILDKITE_ANALYTICS_URL || DEFAULT_BUILDKITE_ANALYTICS_URL
+    const buildkiteAnalyticsUrl = process.env.BUILDKITE_ANALYTICS_BASE_URL || DEFAULT_BUILDKITE_ANALYTICS_BASE_URL
     axios.post(buildkiteAnalyticsUrl, data, config)
     .then(function (response) {
       if(done !== undefined) { return done() }


### PR DESCRIPTION
### Description

This PR allows analytics API to be configured when running a javascript collector. However, the env name conflicts with run env for other CI (see doc).

### Context
https://github.com/buildkite/test-collector-javascript/pull/48#issuecomment-1404268563

### Changes
1. Rename the env variable used to override analytics API URL to `BUILDKITE_ANALYTICS_BASE_URL`