### PR TITLE
[PIE-1415] Bump to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buildkite-test-collector",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "buildkite-test-collector",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "workspaces": [
         "examples/jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "buildkite-test-analytics",
     "buildkite-test-collector"
   ],
-  "version": "1.4.1",
+  "version": "1.4.2",
   "homepage": "https://buildkite.com/test-analytics",
   "bugs": "https://github.com/buildkite/test-collector-javascript/issues",
   "license": "MIT",


### PR DESCRIPTION
Add jasmine and mocha reporters to collector and bump version to 1.4.2
This relates to [PIE-1406](https://linear.app/buildkite/issue/PIE-1406/add-jasmine-and-mocha-reporters-to-npm-package), with work from https://github.com/buildkite/test-collector-javascript/pull/45

---
Diff: https://github.com/buildkite/test-collector-javascript/compare/v1.4.1...v1.4.2
[Linear Ticket](https://linear.app/buildkite/issue/PIE-1415/bump-test-collector-js)