### PR TITLE
[PIE-1479] Remove identifier from reporters

### DIFF
--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -64,13 +64,11 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
-      expect(json).toHaveProperty("data[0].identifier", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "spec/example.spec.js:7")
       expect(json).toHaveProperty("data[0].file_name", "spec/example.spec.js")
       expect(json).toHaveProperty("data[0].result", 'passed')
 
       expect(json).toHaveProperty("data[1].name", "40 + 1 equal 42")
-      expect(json).toHaveProperty("data[1].identifier", "sum 40 + 1 equal 42")
       expect(json).toHaveProperty("data[1].location", "spec/example.spec.js:13")
       expect(json).toHaveProperty("data[1].file_name", "spec/example.spec.js")
       expect(json).toHaveProperty("data[1].result", "failed")

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -72,14 +72,12 @@ describe('examples/jest', () => {
 
       expect(json).toHaveProperty("data[0].scope", '')
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
-      expect(json).toHaveProperty("data[0].identifier", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "example.test.js:2")
       expect(json).toHaveProperty("data[0].file_name", "example.test.js")
       expect(json).toHaveProperty("data[0].result", 'passed')
 
       expect(json).toHaveProperty("data[1].scope", "sum")
       expect(json).toHaveProperty("data[1].name", "40 + 1 equal 42")
-      expect(json).toHaveProperty("data[1].identifier", "sum 40 + 1 equal 42")
       expect(json).toHaveProperty("data[1].location", "example.test.js:8")
       expect(json).toHaveProperty("data[1].file_name", "example.test.js")
       expect(json).toHaveProperty("data[1].result", "failed")

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -65,14 +65,12 @@ describe('examples/mocha', () => {
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
-      expect(json).toHaveProperty("data[0].identifier", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "test.js") // Mocha does not report test line numbers, otherwise we'd see it here
       expect(json).toHaveProperty("data[0].file_name", "test.js")
       expect(json).toHaveProperty("data[0].result", 'passed')
 
       expect(json).toHaveProperty("data[1].scope", "sum")
       expect(json).toHaveProperty("data[1].name", "40 + 1 equal 42")
-      expect(json).toHaveProperty("data[1].identifier", "sum 40 + 1 equal 42")
       expect(json).toHaveProperty("data[1].location", "test.js")  // Mocha does not report test line numbers, otherwise we'd see it here
       expect(json).toHaveProperty("data[1].file_name", "test.js")
       expect(json).toHaveProperty("data[1].result", "failed")

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -66,7 +66,6 @@ class JasmineBuildkiteAnalyticsReporter {
     this._testResults.push({
       'id': id,
       'name': result.description,
-      'identifier': result.fullName,
       'location': result.location ? `${prefixedTestPath}:${result.location.line}` : null,
       'file_name': prefixedTestPath,
       'result': this.analyticsResult(result),

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -39,7 +39,6 @@ class JestBuildkiteAnalyticsReporter {
         'id': id,
         'scope': result.ancestorTitles.join(' '),
         'name': result.title,
-        'identifier': result.fullName,
         'location': result.location ? `${prefixedTestPath}:${result.location.line}` : null,
         'file_name': prefixedTestPath,
         'result': this.analyticsResult(result),

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -51,7 +51,6 @@ class MochaBuildkiteAnalyticsReporter {
       'id': test.testAnalyticsId,
       'name': test.title,
       'scope': this.scope(test),
-      'identifier': test.fullTitle(),
       'file_name': prefixedTestPath,
       'location': prefixedTestPath,
       'result': this.analyticsResult(test.state),


### PR DESCRIPTION
**Description**
We have removed identifier field from DB test table, and we no longer using it in TA. 
This PR is for removing identifier from all the reporters so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561) 

**Context**
Ticket: https://linear.app/buildkite/issue/PIE-1479/remove-identifier-from-javascript-test-collector-payloads
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

**Changes**
Remove identifier from jest, jasmine and mocha reporter
Fix failing tests caused by the changes

**Verification against buildkite/buildkite at local**

**Verify the changes in jest collector **

- run `npm install` to install all dependencies
- `cd examples/jest`
- run `BUILDKITE_ANALYTICS_TOKEN=xx-local-jest-key BUILDKITE_ANALYTICS_BASE_URL=http://analytics-api.buildkite.localhost/v1/uploads npm test` (`xx-local-jest-key` is the api token for the jest suite in my local machine)


**Verify the changes in jasmine collector**
- run `BUILDKITE_ANALYTICS_TOKEN=<your jasmine test suite's api token> BUILDKITE_ANALYTICS_BASE_URL=http://analytics-api.buildkite.localhost/v1/uploads npm test` under `example/jasmine/spec`

**Verify the changes in mocha collector**
- run `BUILDKITE_ANALYTICS_TOKEN=<your mocha test suite's api token> BUILDKITE_ANALYTICS_BASE_URL=http://analytics-api.buildkite.localhost/v1/uploads npm test` under `example/mocha`

**Results:**
- Jest tests are running without errors
- Runs and executions are created in DB without errors
- S3 file doesn't have `identifier` included


