### PR TITLE
PIE-1842: Add build_id to collector

### DIFF
--- a/util/ci.js
+++ b/util/ci.js
@@ -40,6 +40,7 @@ class CI {
       "branch": process.env.BUILDKITE_ANALYTICS_BRANCH,
       "commit_sha": process.env.BUILDKITE_ANALYTICS_SHA,
       "number": process.env.BUILDKITE_ANALYTICS_NUMBER,
+      "build_id": process.env.BUILDKITE_BUILD_ID,
       "job_id": process.env.BUILDKITE_ANALYTICS_JOB_ID,
       "message": process.env.BUILDKITE_ANALYTICS_MESSAGE,
       "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
@@ -66,6 +67,7 @@ class CI {
       "number": process.env.BUILDKITE_BUILD_NUMBER,
       "job_id": process.env.BUILDKITE_JOB_ID,
       "message": process.env.BUILDKITE_MESSAGE,
+      "build_id": process.env.BUILDKITE_BUILD_ID
     })
   }
 
@@ -77,17 +79,19 @@ class CI {
       "branch": process.env.GITHUB_REF,
       "commit_sha": process.env.GITHUB_SHA,
       "number": process.env.GITHUB_RUN_NUMBER,
+      "build_id": `${process.env.GITHUB_ID}-${process.env.GITHUB_RUN_ATTEMPT}`
     })
   }
 
   circleci() {
     return({
       "ci": "circleci",
-      "key": `${process.env.CIRCLE_WORKFLOW_ID}-${process.env.CIRCLE_BUILD_NUM}`,
+      "key": process.env.CIRCLE_WORKFLOW_ID,
       "url": process.env.CIRCLE_BUILD_URL,
       "branch": process.env.CIRCLE_BRANCH,
       "commit_sha": process.env.CIRCLE_SHA1,
-      "number": process.env.CIRCLE_BUILD_NUM,
+      "number": process.env.CIRCLE_WORKFLOW_ID,
+      "build_id": process.env.CIRCLE_WORKFLOW_ID
     })
   }
 }


### PR DESCRIPTION
## Description
As part of the flexi-test-grouping work, new env vars are required to create the new build views in TA. We noted that vars from other ci providers do not directly map to Buildkite's, so some tweaks have been made to the github and circleci `:env`.
As these run_env variables are internal to the collector and the required ENV VARs are being passed already, there is no required update to the js collector docs.

Bump to version will occur in a future PR.

## Context
[PIE-1842](https://linear.app/buildkite/issue/PIE-1842/patch-test-collector-javascript-to-send-new-env-attributes)

## Changes
- Added build_id to collector ci env
- Tweak existing values based on feedback on https://github.com/buildkite/test-collector-ruby/pull/197

## Deploy risk
Low risk