### PR TITLE
Enable JUnit output from Jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+junit.xml

--- a/buildkite.yaml
+++ b/buildkite.yaml
@@ -10,3 +10,7 @@ steps:
           # BUILDKITE_BUILD_ID are passed through to the container and mess up
           # the CI detection — we want a clean state process.env for testing.
           mount-buildkite-agent: false
+      - test-collector#v1.10.0:
+          files:
+            - "junit.xml"
+          format: "junit"

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -50,7 +50,7 @@ describe('examples/jest', () => {
 
       done()
     })
-  }, 1000) // 1s timeout
+  }, 10000) // 10s timeout
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -106,7 +106,7 @@ module.exports = {
   // projects: undefined,
 
   // Use this configuration option to add custom reporters to Jest
-  // reporters: undefined,
+  reporters: [ "default", "jest-junit" ],
 
   // Automatically reset mock state before every test
   // resetMocks: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "jasmine": "^4.2.1",
         "jest": "^29.3.1",
+        "jest-junit": "^16.0.0",
         "mocha": "^10.0.0",
         "mocha-multi-reporters": "^1.5.1"
       },
@@ -70,6 +71,7 @@
       }
     },
     "examples/mocha": {
+      "name": "buildkite-test-collector-mocha-example",
       "devDependencies": {
         "buildkite-test-collector": "file:../..",
         "mocha": "^10.0.0",
@@ -2496,6 +2498,21 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -4016,6 +4033,18 @@
         "node": "*"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mocha": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
@@ -5023,6 +5052,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6172,6 +6207,7 @@
         "dotenv": "^16.0.2",
         "jasmine": "^4.2.1",
         "jest": "^29.3.1",
+        "jest-junit": "^16.0.0",
         "mocha": "^10.0.0",
         "mocha-multi-reporters": "^1.5.1",
         "request-spy": "^0.0.10",
@@ -8796,6 +8832,18 @@
             "walker": "^1.0.8"
           }
         },
+        "jest-junit": {
+          "version": "16.0.0",
+          "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+          "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "strip-ansi": "^6.0.1",
+            "uuid": "^8.3.2",
+            "xml": "^1.0.1"
+          }
+        },
         "jest-leak-detector": {
           "version": "28.1.3",
           "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -9209,6 +9257,12 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         },
         "mocha": {
           "version": "10.0.0",
@@ -9945,6 +9999,12 @@
             "imurmurhash": "^0.1.4",
             "signal-exit": "^3.0.7"
           }
+        },
+        "xml": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+          "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+          "dev": true
         },
         "y18n": {
           "version": "5.0.8",
@@ -11597,6 +11657,18 @@
         "walker": "^1.0.8"
       }
     },
+    "jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      }
+    },
     "jest-leak-detector": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-28.1.3.tgz",
@@ -12010,6 +12082,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "mocha": {
       "version": "10.0.0",
@@ -12746,6 +12824,12 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "jasmine": "^4.2.1",
     "jest": "^29.3.1",
+    "jest-junit": "^16.0.0",
     "mocha": "^10.0.0",
     "mocha-multi-reporters": "^1.5.1"
   },


### PR DESCRIPTION
I'd like to have a demo suite of an open source codebase we can use while building public suites for TA. Using one of our collectors as an example seemed like the easiest place to start, but I expect it will change in future.

In theory it might be possible to use a recursive solution and use the Javascript Collector for the Javascript Collector (using this repo against itself); however, that seemed unnecessarily complicated and risky. I felt it was easier to use a standard JUnit formatter. The results are uploaded using the collector plugin.