### PR TITLE
Guard against possibility of test.err.multiple being undefined in mocha reporter

### DIFF
--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -55,7 +55,7 @@ class MochaBuildkiteAnalyticsReporter {
       'location': prefixedTestPath,
       'result': this.analyticsResult(test.state),
       'failure_reason': failureReason,
-      'failure_expanded': failureExpanded(test.err == undefined ? [] : test.err.multiple),
+      'failure_expanded': failureExpanded(test.err == undefined ? [] : (test.err.multiple || [test.err])),
       'history': {
         'section': 'top',
         'start_at': test.startAt,


### PR DESCRIPTION
When using this reporter when running tests with [mocha-parallel-tests](https://www.npmjs.com/package/mocha-parallel-tests), differences in the `err` object cause an error that prevents the tests being reported. See issue https://github.com/buildkite/test-collector-javascript/issues/57 for an example.

```
// err object in mocha
AssertionError [ERR_ASSERTION]: 41 == 42
    at Context.<anonymous> (test.js:11:12)
    at process.processImmediate (node:internal/timers:471:21) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: '41',
  expected: '42',
  operator: '==',
  multiple: [Array]
}

// err object in mocha-parallel-tests
{
  message: '41 == 42',
  name: 'AssertionError',
  stack: 'AssertionError [ERR_ASSERTION]: 41 == 42\n' +
    '    at Context.<anonymous> (test.js:11:12)\n' +
    '    at process.processImmediate (node:internal/timers:471:21)'
}
```

This change removes the expectation that the `err.multiple` property will always be present and prevents the error.