### PR TITLE
[PIE-2036] upload test results via Mocha done hooks

### DIFF
--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -45,6 +45,12 @@ describe('examples/mocha', () => {
     }, 10000) // 10s timeout
   })
 
+  test('it exits with exit code 1', (done) => {
+    exec('npm test', { cwd, env }, (error, stdout, stderr) => {
+      expect(error.code).toBe(1);
+      done()
+    })
+  });
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
@@ -78,10 +84,20 @@ describe('examples/mocha', () => {
       expect(json.data[1].failure_reason).toMatch('AssertionError [ERR_ASSERTION]: 41 == 42')
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
+      expect(stdout).toMatch(/^Test Analytics .* response/m)
 
       done()
     })
   }, 10000) // 10s timeout
+
+  describe('when --exit option is enabled', () => {
+    test('it sends the JSON to Buildkite Test Analytics', (done) => {
+      exec('npm test -- --exit', { cwd, env }, (error, stdout, stderr) => {
+        expect(stdout).toMatch(/^Test Analytics .* response/m)
+        done()
+      })
+    })
+  })
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -7,10 +7,8 @@ const uploadTestResults = require('../util/uploadTestResults')
 const failureExpanded = require('../util/failureExpanded')
 
 const {
-  EVENT_RUN_END,
   EVENT_TEST_BEGIN,
   EVENT_TEST_END,
-  EVENT_TEST_PENDING,
 } = Mocha.Runner.constants
 
 const {
@@ -32,9 +30,6 @@ class MochaBuildkiteAnalyticsReporter {
       })
       .on(EVENT_TEST_END, (test) => {
         this.testFinished(test)
-      })
-      .on(EVENT_RUN_END, () => {
-        this.testRunFinished()
       })
   }
 
@@ -65,8 +60,13 @@ class MochaBuildkiteAnalyticsReporter {
     })
   }
 
-  testRunFinished() {
-    uploadTestResults(this._testEnv, this._testResults, this._options)
+  // This function will be called when Mocha has finished running all tests.
+  // It behaves similarly to runner.on(EVENT_RUN_END, ...).
+  // The difference is that runner.on(EVENT_RUN_END, ...) will exit the process immediately when `--exit` option is used.
+  // On the other hand, done() can be used to wait for an async process and programatically exit the process, even when `--exit` option is used.
+  // ref: https://github.com/mochajs/mocha/pull/1218
+  done(_failures, exit) {
+    uploadTestResults(this._testEnv, this._testResults, this._options, exit)
   }
 
   analyticsResult(state) {


### PR DESCRIPTION
### Description
Running Mocha with `--exit` option will interrupt the process that send the test results to Buildkite Test Analytics. This behaviour is similar to running Jest with `--forceExit` option. After digging into Mocha internal source code, I found [`done`](https://github.com/mochajs/mocha/blob/37deed262d4bc0788d32c66636495d10038ad398/lib/mocha.js#L1010) hook that will be called before exiting. This hook is also used internally by [`mocha-multiple-reporter`](https://github.com/stanleyhlng/mocha-multi-reporters/blob/56f3c932d4df29b6b2e513f37e26ad486d95b429/lib/MultiReporters.js#L109) package that is required for test collector to work.

This PR moves the upload process from `runner.on(EVENT_RUN_END, ...)` hook to `done` hook. I have added the tests to make sure that we get response from Buildkite API after running the tests with or without `--exit` option.

This resolve #73 & #74  

### Validation

1. Running Mocha with or without `--exit` should report the test results to Test Analytics.
2. Mocha should exit with code `1` when there is a failure