### PR TITLE
Better error reporting for Playwright reporter

### DIFF
--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -95,6 +95,48 @@ describe('examples/playwright', () => {
     }, TIMEOUT)
   })
 
+  describe('when --timeout is exceeded', () => {
+    test("it posts the failures", async () => {
+      const stdout = await runPlaywright(["--timeout=1"], env)
+
+      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const data = JSON.parse(jsonMatch[1])["data"];
+
+      expect(data).toHaveProperty("format", "json")
+
+      expect(data).toHaveProperty("run_env.ci")
+      expect(data).toHaveProperty("run_env.debug", 'true')
+      expect(data).toHaveProperty("run_env.key")
+      expect(data).toHaveProperty("run_env.version")
+      expect(data).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
+
+      expect(data).toHaveProperty("data[0].scope", ' chromium example.spec.js has title')
+      expect(data).toHaveProperty("data[0].name", 'has title')
+      expect(data).toHaveProperty("data[0].location", "tests/example.spec.js:3:1")
+      expect(data).toHaveProperty("data[0].file_name", "tests/example.spec.js")
+      expect(data).toHaveProperty("data[0].result", 'failed')
+      expect(data).toHaveProperty("data[1].failure_reason", "Test timeout of 1ms exceeded.")
+      expect(data).toHaveProperty("data[1].failure_expanded", expect.arrayContaining([
+        expect.objectContaining({
+          expanded: expect.arrayContaining(["Test timeout of 1ms exceeded."])
+        })
+      ]))
+
+      expect(data).toHaveProperty("data[1].scope", " chromium example.spec.js says hello")
+      expect(data).toHaveProperty("data[1].name", "says hello")
+      expect(data).toHaveProperty("data[1].location", "tests/example.spec.js:9:1")
+      expect(data).toHaveProperty("data[1].file_name", "tests/example.spec.js")
+      expect(data).toHaveProperty("data[1].result", "failed")
+      expect(data).toHaveProperty("data[1].failure_reason", "Test timeout of 1ms exceeded.")
+      expect(data).toHaveProperty("data[1].failure_expanded", expect.arrayContaining([
+        expect.objectContaining({
+          expanded: expect.arrayContaining(["Test timeout of 1ms exceeded."])
+        })
+      ]))
+      expect(stdout).toMatch(/^Test Analytics .* response/m)
+    }, TIMEOUT)
+  })
+
   test('it supports test location prefixes for monorepos', async () => {
     const stdout = await runPlaywright([], { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" })
 

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -72,7 +72,7 @@ describe('examples/playwright', () => {
     expect(data).toHaveProperty("data[1].location", "tests/example.spec.js:9:1")
     expect(data).toHaveProperty("data[1].file_name", "tests/example.spec.js")
     expect(data).toHaveProperty("data[1].result", "failed")
-    expect(data).toHaveProperty("data[1].failure_reason", "Error: Timed out 5000ms waiting for expect(received).toHaveText(expected)")
+    expect(data).toHaveProperty("data[1].failure_reason", "Timed out 5000ms waiting for expect(received).toHaveText(expected)")
     expect(data).toHaveProperty("data[1].failure_expanded", expect.arrayContaining([
       expect.objectContaining({
         expanded: expect.arrayContaining(['Expected string: "Hello, World!"', 'Received string: ""'])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buildkite-test-collector",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "buildkite-test-collector",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "workspaces": [
         "examples/jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "buildkite-test-analytics",
     "buildkite-test-collector"
   ],
-  "version": "1.6.2",
+  "version": "1.6.3",
   "homepage": "https://buildkite.com/test-analytics",
   "bugs": "https://github.com/buildkite/test-collector-javascript/issues",
   "license": "MIT",

--- a/playwright/reporter.js
+++ b/playwright/reporter.js
@@ -92,21 +92,12 @@ class PlaywrightBuildkiteAnalyticsReporter {
    *
    * @param {TestResult} testResult
    */
-  analyticsFailureMessages(testResult) {
-    if (testResult.error == undefined) return [];
-
-    const stack = stripAnsi(testResult.error.stack).split("\n");
-    const snippet = stripAnsi(testResult.error.snippet).split("\n");
-
-    return stack.concat(snippet);
-  }
-
-  /**
-   *
-   * @param {TestResult} testResult
-   */
   analyticsFailureReason(testResult) {
-    return this.analyticsFailureMessages(testResult)[0];
+    if (testResult.error == undefined) return "";
+
+    const reason = stripAnsi(testResult.error.message).split("\n")[0];
+
+    return reason;
   }
 
   /**
@@ -114,9 +105,24 @@ class PlaywrightBuildkiteAnalyticsReporter {
    * @param {TestResult} testResult
    */
   analyticsFailureExpanded(testResult) {
+    let expandedErrors = [];
+
+    if (testResult.errors) {
+      for (const error of testResult.errors) {
+        if (error.stack) {
+          const stack = stripAnsi(error.stack).split("\n");
+          const snippet = stripAnsi(error.snippet)?.split("\n") || [];
+          expandedErrors = expandedErrors.concat(stack, snippet);
+        } else if (error.message) {
+          const message = stripAnsi(error.message).split("\n");
+          expandedErrors = expandedErrors.concat(message);
+        }
+      }
+    }
+
     return [
       {
-        expanded: this.analyticsFailureMessages(testResult).splice(1)
+        expanded: expandedErrors
       }
     ];
   }


### PR DESCRIPTION
This constructs a better `failure_reason` and `failure_expanded` for the Playwright reporter, fixing a couple of issues:

1. When running tests with retries enabled, the failures before the final failure do not have `stack` or `snippet` attributes on `testResult.error` (both coming back undefined).  They _do_ have a `message` attribute, however.  Note _singular_ `testResult.error`.

2. However, `testResult.errors` (plural) _do_ contain stacks and snippets, but not necessarily on the first one returned by `error`.

So what this change does is:

1. For the `failure_reason`, return the first line of `testResult.error.message`.  This seems to always exist, and be the short-form message you'd expect here.

2. For `failure_expanded`, loop through all of the `testResult.errors` (plural), and append `stack` + `snippet` if they exist, and `message` otherwise.  Note that `stack` seems to always include `message`, so only one or the other is necessary.

This should _actually_ fix the `Error in reporter TypeError: Cannot read properties of undefined (reading 'split')` error reported in https://github.com/buildkite/test-collector-javascript/pull/78, which was actually because `testResult.error.stack` was often `undefined`.  (That PR is still worthwhile, since we should be properly including dependencies instead of just implicitly including them, but it didn't actually fix the error.  This should!)