### PR TITLE
Ensure `done` fn always called once after test run

### DIFF
--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -6,10 +6,12 @@ const DEFAULT_BUILDKITE_ANALYTICS_BASE_URL = 'https://analytics-api.buildkite.co
 
 const uploadTestResults = (env, results, options, done) => {
   const buildkiteAnalyticsToken = options?.token || process.env.BUILDKITE_ANALYTICS_TOKEN
-  let data
+  const buildkiteAnalyticsUrl = options?.url || process.env.BUILDKITE_ANALYTICS_BASE_URL || DEFAULT_BUILDKITE_ANALYTICS_BASE_URL
 
   if (!buildkiteAnalyticsToken) {
     console.error('Missing BUILDKITE_ANALYTICS_TOKEN')
+
+    if (done !== undefined) { return done() }
     return
   }
 
@@ -20,52 +22,52 @@ const uploadTestResults = (env, results, options, done) => {
     }
   }
 
-  for (let i=0; i < results.length; i += CHUNK_SIZE) {
-    data = {
+  const requests = [];
+
+  if (Debug.enabled()) {
+    axios.interceptors.request.use(function (config) {
+      Debug.log(`Test Analytics Sending: ${JSON.stringify(config)}`);
+      return config;
+    }, function (error) {
+      if (error.response) {
+        Debug.log(`Test Analytics request error: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+      } else {
+        Debug.log(`Test Analytics request error: ${error.message}`)
+      }
+      // Do something with request error
+      return Promise.reject(error);
+    });
+
+    // Add a response interceptor
+    axios.interceptors.response.use(function (response) {
+      // Any status code that lie within the range of 2xx cause this function to trigger
+      // Do something with response data
+      Debug.log(`Test Analytics success response ${JSON.stringify(response.data)}`);
+      return response;
+    }, function (error) {
+      if (error.response) {
+        Debug.log(`Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+      } else {
+        Debug.log(`Test Analytics error: ${error.message}`)
+      }
+      return Promise.reject(error);
+    });
+  }
+
+  for (let i = 0; i < results.length; i += CHUNK_SIZE) {
+    const data = {
       'format': 'json',
       'run_env': env,
       "data": results.slice(i, i + CHUNK_SIZE),
     }
 
-    if (Debug.enabled()){
-      axios.interceptors.request.use(function (config) {
-        Debug.log(`Test Analytics Sending: ${JSON.stringify(config)}`);
-        return config;
-      }, function (error) {
-        if (error.response) {
-          Debug.log(`Test Analytics request error: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
-        } else {
-          Debug.log(`Test Analytics request error: ${error.message}`)
-        }
-        // Do something with request error
-        return Promise.reject(error);
-      });
-
-      // Add a response interceptor
-      axios.interceptors.response.use(function (response) {
-        // Any status code that lie within the range of 2xx cause this function to trigger
-        // Do something with response data
-        Debug.log(`Test Analytics success response ${JSON.stringify(response.data)}`);
-        return response;
-      }, function (error) {
-        if (error.response) {
-          Debug.log(`Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
-        } else {
-          Debug.log(`Test Analytics error: ${error.message}`)
-        }
-        return Promise.reject(error);
-      });
-    }
-
-    const buildkiteAnalyticsUrl = process.env.BUILDKITE_ANALYTICS_BASE_URL || DEFAULT_BUILDKITE_ANALYTICS_BASE_URL
-    axios.post(buildkiteAnalyticsUrl, data, config)
-    .then(function (response) {
-      if(done !== undefined) { return done() }
-    })
-    .catch(function (error) {
-      if(done !== undefined) { return done() }
-    })
+    requests.push(axios.post(buildkiteAnalyticsUrl, data, config))
   }
+
+  return Promise.all(requests)
+    .finally(function (responses) {
+      if (done !== undefined) { return done() }
+    })
 }
 
 module.exports = uploadTestResults


### PR DESCRIPTION
### Description
A customer found a bug in the test collector that caused the test runner to exit with successful exit code (0) even if there is a failure. One way to reproduce this issue locally is by adding `beforeEach` block that throws an error in [Mocha example](https://github.com/buildkite/test-collector-javascript/blob/7bc7a4977500ca80b3e87e7057aebf70195d6037/examples/mocha/test.js). This happened because in that scenario, the test result will be empty and the `done` function is not being called by [uploadTestResults](https://github.com/buildkite/test-collector-javascript/blob/5d8839557563f6e8a0b4b2edd1ca7555d6e11a35/util/uploadTestResults.js#L63), causing the test runner to exit with incorrect exit code. The customer also pointed out that when the test results are more than 5000 (`CHUNK_SIZE`), the process will exit prematurely and the subsequent chunk of result will not be uploaded.

This PR ensure that `done` function is always called once and after all upload requests has been finished.

### Changes
- Fixed `uploadTestResults` to ensure `done` always called once
- Add specs to assert the behaviour

### Verification
Reproduce the issue (see above description), and make sure the right exit code is returned

