### PR TITLE
[PIE-2410] Bump axios from 1.6.2 to 1.6.8 to address CVE-2024-28849

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "examples/cypress"
       ],
       "dependencies": {
-        "axios": "^1.0.0",
+        "axios": "^1.6.8",
         "dotenv": "^16.0.2",
         "request-spy": "^0.0.10",
         "strip-ansi": "^6.0.0",
@@ -2750,11 +2750,11 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -4782,9 +4782,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -10823,11 +10823,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       },
@@ -11030,7 +11030,7 @@
       "version": "file:",
       "requires": {
         "@playwright/test": "^1.38.1",
-        "axios": "^1.0.0",
+        "axios": "1.6.8",
         "buildkite-test-collector-cypress-example": "file:examples/cypress",
         "buildkite-test-collector-jasmine-example": "file:examples/jasmine",
         "buildkite-test-collector-jest-example": "file:examples/jest",
@@ -12776,11 +12776,11 @@
           "dev": true
         },
         "axios": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-          "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+          "version": "1.6.8",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+          "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
           "requires": {
-            "follow-redirects": "^1.15.0",
+            "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
           },
@@ -14148,9 +14148,9 @@
           "dev": true
         },
         "follow-redirects": {
-          "version": "1.15.3",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-          "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+          "version": "1.15.6",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+          "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -18091,9 +18091,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "util/"
   ],
   "dependencies": {
-    "axios": "^1.0.0",
+    "axios": "^1.6.8",
     "dotenv": "^16.0.2",
     "request-spy": "^0.0.10",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
CVE-2024-28849
https://github.com/advisories/GHSA-cxjh-pqwp-8mfpk
https://github.com/axios/axios/pull/6300
https://github.com/axios/axios/releases/tag/v1.6.8

Tracked internally https://linear.app/buildkite/issue/PIE-2410/bump-axois-in-javascript-collector-to-address-security-vuln
