### PR TITLE
Fix async problem in jest reporter when trying to run `onRunComplete`

### DIFF
--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -23,8 +23,8 @@ class JestBuildkiteAnalyticsReporter {
     }
   }
 
-  async onRunComplete(_test, _results, _options) {
-    await uploadTestResults(this._testEnv, this._testResults, this._options)
+  onRunComplete(_test, _results, _options) {
+    return uploadTestResults(this._testEnv, this._testResults, this._options)
   }
 
   onTestStart(test) {

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -23,8 +23,8 @@ class JestBuildkiteAnalyticsReporter {
     }
   }
 
-  onRunComplete(_test, _results, _options) {
-    uploadTestResults(this._testEnv, this._testResults, this._options)
+  async onRunComplete(_test, _results, _options) {
+    await uploadTestResults(this._testEnv, this._testResults, this._options)
   }
 
   onTestStart(test) {


### PR DESCRIPTION
Hi, I'm seeing an issue in my project where `onRunComplete` isn't quite being awaited in some of our BK pipeline.

I was debugging the problem and found that https://github.com/jestjs/jest/blob/main/packages/jest-core/src/ReporterDispatcher.ts#L101 the latest versions of Jest's ReportDispatcher does not rely on `done` method, but it is based on async/await. Which means that `done` is not guaranteed to exist in most of the newer versions of Jest.

As a result, unless you configure Jest to wait for a little bit before it `exit`, it doesn't successfully send the reports back to BuildKite.

ReportDispatcher.ts in the latest Jest as an example https://github.com/jestjs/jest/blob/main/packages/jest-core/src/ReporterDispatcher.ts#L101