### PR TITLE
Modify instructions for testLocationInResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
       'default',
       'buildkite-test-collector/jest/reporter'
     ],
-
-    // Enable column + line capture for Test Analytics
-    testLocationInResults: true
     ```
+
+    Ensure that you run Jest with the `--testLocationInResults` flag so that column + line information is captured for Test Analytics
 
     If you would like to pass in the API token using a custom environment variable, you can do so using the report options.
 

--- a/examples/jest/jest.config.js
+++ b/examples/jest/jest.config.js
@@ -3,10 +3,7 @@ const config = {
   reporters: [
     'default',
     'buildkite-test-collector/jest/reporter'
-  ],
-
-  // Enable column + line capture for Test Analytics
-  testLocationInResults: true
+  ]
 };
 
 module.exports = config;

--- a/examples/jest/token.config.js
+++ b/examples/jest/token.config.js
@@ -3,10 +3,7 @@ const config = {
   reporters: [
     'default',
     ['buildkite-test-collector/jest/reporter', { token: process.env.BUILDKITE_ANALYTICS_JEST_TOKEN }]
-  ],
-
-  // Enable column + line capture for Test Analytics
-  testLocationInResults: true
+  ]
 };
 
 module.exports = config;

--- a/jest.config.js
+++ b/jest.config.js
@@ -149,9 +149,6 @@ module.exports = {
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},
 
-  // Adds a location field to test results
-  // testLocationInResults: false,
-
   // The glob patterns Jest uses to detect test files
   // testMatch: [
   //   "**/__tests__/**/*.[jt]s?(x)",


### PR DESCRIPTION
This option can only be set as a CLI flag.  It is not a valid option in the configuration file and is silently ignored if set.