### PR TITLE
Silent errors from upload

### DIFF
--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -82,7 +82,7 @@ describe('examples/cypress', () => {
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
 
-      expect(stdout).toMatch(/^Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Analytics .* response/m)
       done()
     })
   }, DEFAULT_TIMEOUT)

--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -107,6 +107,11 @@ describe('examples/cypress', () => {
   }, DEFAULT_TIMEOUT)
 
   describe('when test is pass but upload fails', () => {
+    beforeAll(() => {
+      // This will cause the upload to fail
+      env.BUILDKITE_ANALYTICS_BASE_URL = "http://"
+    })
+
     test('it should not throw an error', (done) => {
       exec('npm test -- --spec cypress/component/passed.cy.js', { cwd, env }, (error, stdout, stderr) => {
         expect(error).toBeNull()

--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -47,7 +47,6 @@ describe('examples/cypress', () => {
     }, DEFAULT_TIMEOUT)
   })
 
-
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
       expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
@@ -106,4 +105,14 @@ describe('examples/cypress', () => {
       done()
     })
   }, DEFAULT_TIMEOUT)
+
+  describe('when test is pass but upload fails', () => {
+    test('it should not throw an error', (done) => {
+      exec('npm test -- --spec cypress/component/passed.cy.js', { cwd, env }, (error, stdout, stderr) => {
+        expect(error).toBeNull()
+
+        done()
+      })
+    }, DEFAULT_TIMEOUT)
+  })
 })

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -108,6 +108,11 @@ describe('examples/jasmine', () => {
   }, 10000) // 10s timeout
 
   describe('when test is pass but upload fails', () => {
+    beforeAll(() => {
+      // This will cause the upload to fail
+      env.BUILDKITE_ANALYTICS_BASE_URL = "http://"
+    })
+
     test('it should not throw an error', done => {
       exec("npm test spec/passed.spec.js", { cwd, env }, (error, stdout) => {
         expect(error).toBeNull()

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -106,4 +106,14 @@ describe('examples/jasmine', () => {
       done()
     })
   }, 10000) // 10s timeout
+
+  describe('when test is pass but upload fails', () => {
+    test('it should not throw an error', done => {
+      exec("npm test spec/passed.spec.js", { cwd, env }, (error, stdout) => {
+        expect(error).toBeNull()
+
+        done()
+      })
+    })
+  })
 })

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -114,8 +114,14 @@ describe('examples/jest', () => {
   }, 10000) // 10s timeout
 
   describe('when test is pass but upload fails', () => {
+    beforeAll(() => {
+      // This will cause the upload to fail
+      env.BUILDKITE_ANALYTICS_BASE_URL = "http://"
+    })
+
     test('it should not throw an error', (done) => {
       exec('npm test passed.test.js', { cwd, env }, (error, stdout, stderr) => {
+        console.log(stdout)
         expect(error).toBeNull()
 
         done()

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -112,4 +112,14 @@ describe('examples/jest', () => {
       done()
     })
   }, 10000) // 10s timeout
+
+  describe('when test is pass but upload fails', () => {
+    test('it should not throw an error', (done) => {
+      exec('npm test passed.test.js', { cwd, env }, (error, stdout, stderr) => {
+        expect(error).toBeNull()
+
+        done()
+      })
+    })
+  })
 })

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -17,16 +17,16 @@ describe('examples/mocha', () => {
   describe('when token is defined through reporter options', () => {
     test('it uses the correct token', (done) => {
       exec('mocha --reporter mocha-multi-reporters --reporter-options configFile=token-config.json',
-      { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
+          expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
-        const json = JSON.parse(jsonMatch[1])["headers"]
+          const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+          const json = JSON.parse(jsonMatch[1])["headers"]
 
-        expect(json).toHaveProperty("Authorization", 'Token token="abc"')
+          expect(json).toHaveProperty("Authorization", 'Token token="abc"')
 
-        done()
-      })
+          done()
+        })
     }, 10000) // 10s timeout
   })
 
@@ -117,4 +117,14 @@ describe('examples/mocha', () => {
       done()
     })
   }, 10000) // 10s timeout
+
+  describe('when test is pass but upload fails', () => {
+    test('it should not throw an error', (done) => {
+      exec('npm test passed.test.js', { cwd, env }, (error, stdout, stderr) => {
+        expect(error).toBeNull()
+
+        done()
+      })
+    })
+  })
 })

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -84,7 +84,7 @@ describe('examples/mocha', () => {
       expect(json.data[1].failure_reason).toMatch('AssertionError [ERR_ASSERTION]: 41 == 42')
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
-      expect(stdout).toMatch(/^Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Analytics .* response/m)
 
       done()
     })
@@ -93,7 +93,7 @@ describe('examples/mocha', () => {
   describe('when --exit option is enabled', () => {
     test('it sends the JSON to Buildkite Test Analytics', (done) => {
       exec('npm test -- --exit', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/^Test Analytics .* response/m)
+        expect(stdout).toMatch(/Test Analytics .* response/m)
         done()
       })
     })

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -119,6 +119,11 @@ describe('examples/mocha', () => {
   }, 10000) // 10s timeout
 
   describe('when test is pass but upload fails', () => {
+    beforeAll(() => {
+      // This will cause the upload to fail
+      env.BUILDKITE_ANALYTICS_BASE_URL = "http://"
+    })
+
     test('it should not throw an error', (done) => {
       exec('npm test passed.test.js', { cwd, env }, (error, stdout, stderr) => {
         expect(error).toBeNull()

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -150,6 +150,10 @@ describe('examples/playwright', () => {
   }, TIMEOUT);
 
   describe('when test is pass but upload fails', () => {
+    beforeAll(() => {
+      // This will cause the upload to fail
+      env.BUILDKITE_ANALYTICS_BASE_URL = "http://"
+    })
     test('it should not throw an error', done => {
       exec("npm test example.spec.js:3", { cwd, env: { ...env, JEST_WORKER_ID: undefined } }, (error, stdout) => {
         expect(error).toBeNull()

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -6,8 +6,8 @@ const path = require('path');
 
 const TIMEOUT = 20000;
 
+const cwd = path.join(__dirname, "../examples/playwright");
 const runPlaywright = (args, env) => {
-  const cwd = path.join(__dirname, "../examples/playwright");
 
   return new Promise((resolve) => {
     const command = `npm test -- ${args.join(' ')}`
@@ -87,7 +87,7 @@ describe('examples/playwright', () => {
 
       const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
       const data = JSON.parse(jsonMatch[1])["data"]["data"];
-      
+
       const retriedTest = data.filter(test => test.name === "says hello")
       expect(retriedTest.length).toEqual(2)
       expect(retriedTest.map(test => test.result)).toEqual(["failed", "passed"])
@@ -148,4 +148,14 @@ describe('examples/playwright', () => {
     expect(data).toHaveProperty("data[0].location", "some-sub-dir/tests/example.spec.js:3:1")
     expect(data).toHaveProperty("data[1].location", "some-sub-dir/tests/example.spec.js:9:1")
   }, TIMEOUT);
+
+  describe('when test is pass but upload fails', () => {
+    test('it should not throw an error', done => {
+      exec("npm test example.spec.js:3", { cwd, env: { ...env, JEST_WORKER_ID: undefined } }, (error, stdout) => {
+        expect(error).toBeNull()
+
+        done()
+      })
+    }, TIMEOUT)
+  })
 });

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -78,7 +78,7 @@ describe('examples/playwright', () => {
         expanded: expect.arrayContaining(['Expected string: "Hello, World!"', 'Received string: ""'])
       })
     ]))
-    expect(stdout).toMatch(/^Test Analytics .* response/m)
+    expect(stdout).toMatch(/Test Analytics .* response/m)
   }, TIMEOUT);
 
   describe('when --retries option is used', () => {
@@ -91,7 +91,7 @@ describe('examples/playwright', () => {
       const retriedTest = data.filter(test => test.name === "says hello")
       expect(retriedTest.length).toEqual(2)
       expect(retriedTest.map(test => test.result)).toEqual(["failed", "passed"])
-      expect(stdout).toMatch(/^Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Analytics .* response/m)
     }, TIMEOUT)
   })
 
@@ -133,7 +133,7 @@ describe('examples/playwright', () => {
           expanded: expect.arrayContaining(["Test timeout of 1ms exceeded."])
         })
       ]))
-      expect(stdout).toMatch(/^Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Analytics .* response/m)
     }, TIMEOUT)
   })
 

--- a/examples/cypress/cypress/component/passed.cy.js
+++ b/examples/cypress/cypress/component/passed.cy.js
@@ -1,0 +1,5 @@
+describe("passed", () => {
+  it("is true", () => {
+    expect(true).to.be.true;
+  });
+})

--- a/examples/jasmine/spec/passed.spec.js
+++ b/examples/jasmine/spec/passed.spec.js
@@ -1,0 +1,9 @@
+
+var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
+var buildkiteReporter = new BuildkiteReporter(undefined, { output: process.env.RESULT_PATH });
+jasmine.getEnv().addReporter(buildkiteReporter);
+
+it('is true', () => {
+  expect(true).toBe(true);
+});
+

--- a/examples/jest/passed.test.js
+++ b/examples/jest/passed.test.js
@@ -1,0 +1,5 @@
+describe('passed', () => {
+  it('is true', () => {
+    expect(true).toBeTruthy()
+  });
+})

--- a/examples/mocha/passed.test.js
+++ b/examples/mocha/passed.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert')
+
+// No scope
+it('1 + 2 to equal 3', () => {
+  assert.equal(1 + 2, 3);
+});

--- a/examples/mocha/test.js
+++ b/examples/mocha/test.js
@@ -9,5 +9,5 @@ it('1 + 2 to equal 3', () => {
 describe('sum', () => {
   it('40 + 1 equal 42', () => {
     assert.equal(40 + 1, 42);
-  });  
+  });
 })

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -37,22 +37,22 @@ const uploadTestResults = (env, results, options, done) => {
       // Do something with request error
       return Promise.reject(error);
     });
-
-    // Add a response interceptor
-    axios.interceptors.response.use(function (response) {
-      // Any status code that lie within the range of 2xx cause this function to trigger
-      // Do something with response data
-      Debug.log(`Test Analytics success response ${JSON.stringify(response.data)}`);
-      return response;
-    }, function (error) {
-      if (error.response) {
-        Debug.log(`Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
-      } else {
-        Debug.log(`Test Analytics error: ${error.message}`)
-      }
-      return Promise.reject(error);
-    });
   }
+
+  // Add a response interceptor
+  axios.interceptors.response.use(function (response) {
+    // Any status code that lie within the range of 2xx cause this function to trigger
+    // Do something with response data
+    Debug.log(`Test Analytics success response ${JSON.stringify(response.data)}`);
+    return response;
+  }, function (error) {
+    if (error.response) {
+      console.log(`⚠️ Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+    } else {
+      console.log(`⚠️ Test Analytics error: ${error.message}`)
+    }
+    return Promise.reject(error);
+  });
 
   for (let i = 0; i < results.length; i += CHUNK_SIZE) {
     const data = {

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -64,7 +64,7 @@ const uploadTestResults = (env, results, options, done) => {
     requests.push(axios.post(buildkiteAnalyticsUrl, data, config))
   }
 
-  return Promise.all(requests)
+  return Promise.allSettled(requests)
     .finally(function (responses) {
       if (done !== undefined) { return done() }
     })


### PR DESCRIPTION
When the reporters failed to upload the test data to Buildkite Test Engine, some test runner exits with non-zero code, causing the CI job to fails even all the tests have passed. 

This PR fixes the issue by suppressing the error by replacing `Promise.all` in the `uploadTestResults` function with [Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) to wait for all asysnc http requests, regardless of the outcome. The error message will be printed if there is a failure instead. I have also added a test to each reporter to ensure that the runner exits without error when all tests have passed.

This fixes https://github.com/buildkite/test-collector-javascript/issues/94