### PR TITLE
playwright test server moved to less common port (8080 -> 18080)

### DIFF
--- a/examples/playwright/package.json
+++ b/examples/playwright/package.json
@@ -5,7 +5,7 @@
     "buildkite-test-collector": "file:../.."
   },
   "scripts": {
-    "start": "npx http-server -p 8080",
+    "start": "npx http-server -p 18080",
     "test": "npx playwright test"
   },
   "dependencies": {

--- a/examples/playwright/playwright.config.js
+++ b/examples/playwright/playwright.config.js
@@ -8,10 +8,10 @@ module.exports = defineConfig({
   reporter: [['line'], ['buildkite-test-collector/playwright/reporter']],
   webServer: {
     command: 'npm start',
-    url: 'http://127.0.0.1:8080',
+    url: 'http://127.0.0.1:18080',
   },
   use: {
-    baseURL: 'http://localhost:8080/',
+    baseURL: 'http://localhost:18080/',
   },
 
   /* Configure projects for major browsers */

--- a/examples/playwright/token.config.js
+++ b/examples/playwright/token.config.js
@@ -11,10 +11,10 @@ module.exports = defineConfig({
   ],
   webServer: {
     command: 'npm start',
-    url: 'http://127.0.0.1:8080',
+    url: 'http://127.0.0.1:18080',
   },
   use: {
-    baseURL: 'http://localhost:8080/',
+    baseURL: 'http://localhost:18080/',
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
Running on port 8080 was causing various tests to fail with obscure error message, because I had another service running on port 8080.

A bit of digging showed these messages:

> Error: http://127.0.0.1:8080 is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.

Since 8080 is a pretty common port for local dev servers etc, let's move this playwright test server to something less common. (Dynamically allocated would be ideal, but I'm keeping this change minimal). 18080 is chosen by arbitrarily adding 10000 to the existing port.