### PR TITLE
Introduce `tags` option

### DIFF
--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -65,6 +65,8 @@ describe('examples/cypress', () => {
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
+      expect(json).toHaveProperty("tags", { "hello": "cypress" }) // examples/cypress/cypress.config.js
+
       expect(json).toHaveProperty("data[0].name", 'renders')
       expect(json).toHaveProperty("data[0].identifier", '<Component /> renders')
       expect(json).toHaveProperty("data[0].location", "cypress/component/Component.cy.jsx") // Cypress does not report test line numbers, otherwise we'd see it here

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -63,6 +63,8 @@ describe('examples/jasmine', () => {
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
+      expect(json).toHaveProperty("tags", { "hello": "jasmine" }) // examples/jasmine/spec/example.spec.js
+
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "spec/example.spec.js:7")
       expect(json).toHaveProperty("data[0].file_name", "spec/example.spec.js")

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -70,6 +70,8 @@ describe('examples/jest', () => {
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
+      expect(json).toHaveProperty("tags", { "hello": "jest" }) // examples/jest/jest.config.js
+
       expect(json).toHaveProperty("data[0].scope", '')
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "example.test.js:2")
@@ -121,7 +123,7 @@ describe('examples/jest', () => {
 
     test('it should not throw an error', (done) => {
       exec('npm test passed.test.js', { cwd, env }, (error, stdout, stderr) => {
-        console.log(stdout)
+        //console.log(stdout)
         expect(error).toBeNull()
 
         done()

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -70,6 +70,8 @@ describe('examples/mocha', () => {
       expect(json).toHaveProperty("run_env.version")
       expect(json).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
+      expect(json).toHaveProperty("tags", {"hello": "mocha"}) // examples/mocha/config.json
+
       expect(json).toHaveProperty("data[0].name", '1 + 2 to equal 3')
       expect(json).toHaveProperty("data[0].location", "test.js") // Mocha does not report test line numbers, otherwise we'd see it here
       expect(json).toHaveProperty("data[0].file_name", "test.js")

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -61,6 +61,8 @@ describe('examples/playwright', () => {
     expect(data).toHaveProperty("run_env.version")
     expect(data).toHaveProperty("run_env.collector", "js-buildkite-test-collector")
 
+    expect(data).toHaveProperty("tags", { "hello": "playwright" }) // examples/playwright/playwright.config.js
+
     expect(data).toHaveProperty("data[0].scope", ' chromium example.spec.js has title')
     expect(data).toHaveProperty("data[0].name", 'has title')
     expect(data).toHaveProperty("data[0].location", "tests/example.spec.js:3:1")

--- a/examples/cypress/cypress.config.js
+++ b/examples/cypress/cypress.config.js
@@ -4,6 +4,7 @@ module.exports = defineConfig({
   reporter: "../../cypress/reporter",
   reporterOptions: {
     token_name: "BUILDKITE_ANALYTICS_TOKEN",
+    tags: { "hello": "cypress" },
   },
   component: {
     devServer: {

--- a/examples/jasmine/spec/example.spec.js
+++ b/examples/jasmine/spec/example.spec.js
@@ -1,6 +1,6 @@
 let axios = require('axios')
 var BuildkiteReporter = require('buildkite-test-collector/jasmine/reporter');
-var buildkiteReporter = new BuildkiteReporter();
+var buildkiteReporter = new BuildkiteReporter(undefined, { tags: { hello: "jasmine" }});
 jasmine.getEnv().addReporter(buildkiteReporter);
 
 // No scope

--- a/examples/jest/jest.config.js
+++ b/examples/jest/jest.config.js
@@ -2,7 +2,9 @@ const config = {
   // Send results to Test Analytics
   reporters: [
     'default',
-    'buildkite-test-collector/jest/reporter'
+    ['buildkite-test-collector/jest/reporter', {
+      tags: { hello: "jest" }
+    }]
   ],
 
   // Enable column + line capture for Test Analytics

--- a/examples/mocha/config.json
+++ b/examples/mocha/config.json
@@ -1,3 +1,8 @@
 {
-  "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter"
+  "reporterEnabled": "spec, buildkite-test-collector/mocha/reporter",
+  "buildkiteTestCollectorMochaReporterReporterOptions": {
+    "tags": {
+      "hello": "mocha"
+    }
+  }
 }

--- a/examples/playwright/playwright.config.js
+++ b/examples/playwright/playwright.config.js
@@ -5,7 +5,12 @@ const { defineConfig, devices } = require('@playwright/test');
  */
 module.exports = defineConfig({
   testDir: './tests',
-  reporter: [['line'], ['buildkite-test-collector/playwright/reporter']],
+  reporter: [
+    ['line'],
+    ['buildkite-test-collector/playwright/reporter', {
+      tags: { "hello": "playwright" }
+    }]
+  ],
   webServer: {
     command: 'npm start',
     url: 'http://127.0.0.1:18080',

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -42,6 +42,7 @@ class JasmineBuildkiteAnalyticsReporter {
     this._options = options
     this._testResults = []
     this._testEnv = (new CI()).env();
+    this._tags = options?.tags;
     this._paths = new Paths(config, this._testEnv.location_prefix)
   }
 
@@ -76,7 +77,7 @@ class JasmineBuildkiteAnalyticsReporter {
   }
 
   jasmineDone(result, done) {
-    return uploadTestResults(this._testEnv, this._testResults, this._options, done)
+    return uploadTestResults(this._testEnv, this._tags, this._testResults, this._options, done)
   }
 
   analyticsResult(testResult) {

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -9,6 +9,7 @@ class JestBuildkiteAnalyticsReporter {
     this._options = options
     this._testResults = []
     this._testEnv = (new CI()).env();
+    this._tags = options?.tags;
     this._paths = new Paths(globalConfig, this._testEnv.location_prefix)
   }
 
@@ -24,7 +25,7 @@ class JestBuildkiteAnalyticsReporter {
   }
 
   onRunComplete(_test, _results, _options) {
-    return uploadTestResults(this._testEnv, this._testResults, this._options)
+    return uploadTestResults(this._testEnv, this._tags, this._testResults, this._options)
   }
 
   onTestStart(test) {

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -22,6 +22,7 @@ class MochaBuildkiteAnalyticsReporter {
     this._options = { token: process.env[`${options.reporterOptions.token_name}`]}
     this._testResults = []
     this._testEnv = (new CI()).env();
+    this._tags = options.reporterOptions.tags;
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix)
 
     runner
@@ -66,7 +67,7 @@ class MochaBuildkiteAnalyticsReporter {
   // On the other hand, done() can be used to wait for an async process and programatically exit the process, even when `--exit` option is used.
   // ref: https://github.com/mochajs/mocha/pull/1218
   done(_failures, exit) {
-    uploadTestResults(this._testEnv, this._testResults, this._options, exit)
+    uploadTestResults(this._testEnv, this._tags, this._testResults, this._options, exit)
   }
 
   analyticsResult(state) {

--- a/playwright/reporter.js
+++ b/playwright/reporter.js
@@ -24,6 +24,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
   constructor(options) {
     this._testResults = [];
     this._testEnv = (new CI()).env();
+    this._tags = options?.tags;
     this._options = options;
     this._paths = new Paths({ cwd: process.cwd() }, this._testEnv.location_prefix);
   }
@@ -32,7 +33,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
 
   onEnd() {
     return new Promise(resolve => {
-      uploadTestResults(this._testEnv, this._testResults, this._options, resolve);
+      uploadTestResults(this._testEnv, this._tags, this._testResults, this._options, resolve);
     })
   }
 

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 const CHUNK_SIZE = 5000
 const DEFAULT_BUILDKITE_ANALYTICS_BASE_URL = 'https://analytics-api.buildkite.com/v1/uploads'
 
-const uploadTestResults = (env, results, options, done) => {
+const uploadTestResults = (env, tags, results, options, done) => {
   const buildkiteAnalyticsToken = options?.token || process.env.BUILDKITE_ANALYTICS_TOKEN
   const buildkiteAnalyticsUrl = options?.url || process.env.BUILDKITE_ANALYTICS_BASE_URL || DEFAULT_BUILDKITE_ANALYTICS_BASE_URL
 
@@ -58,6 +58,7 @@ const uploadTestResults = (env, results, options, done) => {
     const data = {
       'format': 'json',
       'run_env': env,
+      'tags': tags || {},
       "data": results.slice(i, i + CHUNK_SIZE),
     }
 


### PR DESCRIPTION
Allow `tags` to be specified for all executions uploaded by the collector; they will propagate onto all the test results (executions) within.

Arbitrary tags may not be supported yet; this is an upcoming/experimental feature. Reach out to Buildkite support for more information if you're interested.

See the `examples/*` changes of this pull request for usage examples. Once the feature has stabilised more we can add examples to the README.

I'm not much of a JavaScript developer, so please let me know if this isn't a good way to pass options to the reporter, or if there's anything else not-quite-right about the implementation 🙏🏼

Related:
- https://github.com/buildkite-plugins/test-collector-buildkite-plugin/pull/81
- https://github.com/buildkite/test-collector-ruby/pull/235