### PR TITLE
Prepare v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,14 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/buildk
 
 ```sh
 # Version bump the code, tag and push
-npm version [major/minor/patch]
-git push && git push --tags
+git switch --create prepare-v1-2-3
+npm version --no-git-tag-version v1.2.3
+git push
+
+# Open a pull request, get it merged
+git switch main
+git tag v1.2.3
+git push --tags
 
 # Publish to the NPM registry
 npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buildkite-test-collector",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "buildkite-test-collector",
-      "version": "1.7.3",
+      "version": "1.8.0",
       "license": "MIT",
       "workspaces": [
         "examples/jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "buildkite-test-analytics",
     "buildkite-test-collector"
   ],
-  "version": "1.7.3",
+  "version": "1.8.0",
   "homepage": "https://buildkite.com/test-analytics",
   "bugs": "https://github.com/buildkite/test-collector-javascript/issues",
   "license": "MIT",


### PR DESCRIPTION
Prepare for v1.8.0 release.

The version bump was done by `npm version minor` although I ran into trouble pushing straight to `main` (which is good!) so I've updated the instructions accordingly.

Here's the auto-generated release notes verbatim (I'll tidy them up when I create the release):

> ## What's Changed
> * Release version 1.7.3 by @nprizal in https://github.com/buildkite/test-collector-javascript/pull/96
> * playwright test server moved to less common port (8080 -> 18080) by @pda in https://github.com/buildkite/test-collector-javascript/pull/99
> * Introduce `tags` option by @pda in https://github.com/buildkite/test-collector-javascript/pull/100
> 
> ## New Contributors
> * @pda made their first contribution in https://github.com/buildkite/test-collector-javascript/pull/99
> 
> **Full Changelog**: https://github.com/buildkite/test-collector-javascript/compare/v1.7.3...v1.8.0