### PR TITLE
Analytics -> Engine renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Buildkite Collectors for JavaScript
 
-Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collectors for JavaScript test frameworks ✨
+Official [Buildkite Test Engine](https://buildkite.com/platform/test-engine) collectors for JavaScript test frameworks ✨
 
 ⚒ **Supported test frameworks:** Jest, Jasmine, Mocha, Cypress, Playwright, and [more coming soon](https://github.com/buildkite/test-collector-javascript/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+frameworks%22).
 
@@ -8,7 +8,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 
 ## 👉 Installing
 
-1. [Create a test suite](https://buildkite.com/docs/test-analytics), and copy the API token that it gives you.
+1. [Create a test suite](https://buildkite.com/docs/test-engine), and copy the API token that it gives you.
 
 2. Add the [`buildkite-test-collector` package](https://www.npmjs.com/package/buildkite-test-collector):
 
@@ -29,13 +29,13 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
     ```js
     // jest.config.js
 
-    // Send results to Test Analytics
+    // Send results to Test Engine
     reporters: [
       'default',
       'buildkite-test-collector/jest/reporter'
     ],
 
-    // Enable column + line capture for Test Analytics
+    // Enable column + line capture for Test Engine
     testLocationInResults: true
     ```
 
@@ -44,7 +44,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
     ```js
     // jest.config.js
 
-    // Send results to Test Analytics
+    // Send results to Test Engine
     reporters: [
       "default",
       [
@@ -122,7 +122,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
     ```js
     // playwright.config.js
 
-    // Send results to Test Analytics
+    // Send results to Test Engine
     reporter: [
       ['line'],
       ['buildkite-test-collector/playwright/reporter']
@@ -134,7 +134,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
     ```js
     // jest.config.js
 
-    // Send results to Test Analytics
+    // Send results to Test Engine
     reporter: [
       ['line'],
       ['buildkite-test-collector/playwright/reporter', { token: process.env.CUSTOM_ENV_VAR },]
@@ -148,7 +148,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
    ```js
     // cypress.config.js
 
-    // Send results to Test Analytics
+    // Send results to Test Engine
    reporter: "buildkite-test-collector/cypress/reporter",
    ```
 
@@ -157,7 +157,7 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
    ```js
    // cypress.config.js
 
-   // Send results to Test Analytics
+   // Send results to Test Engine
    reporterOptions: {
     token_name: "CUSTOM_ENV_VAR_NAME"
    }
@@ -172,9 +172,9 @@ Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collec
 5. Add the `BUILDKITE_ANALYTICS_TOKEN` secret to your CI, push your changes to a branch, and open a pull request 🎉
 
     ```bash
-    git checkout -b add-bk-test-analytics
-    git commit -am "Add Buildkite Test Analytics"
-    git push origin add-bk-test-analytics
+    git checkout -b add-bk-test-engine
+    git commit -am "Add Buildkite Test Engine"
+    git push origin add-bk-test-engine
     ```
 
 ## 📓 Notes
@@ -203,7 +203,7 @@ And run the tests:
 npm test
 ```
 
-Useful resources for developing collectors include the [Buildkite Test Analytics docs](https://buildkite.com/docs/test-analytics) and the [RSpec and Minitest collectors](https://github.com/buildkite/rspec-buildkite-analytics).
+Useful resources for developing collectors include the [Buildkite Test Engine docs](https://buildkite.com/docs/test-engine) and the [RSpec and Minitest collectors](https://github.com/buildkite/rspec-buildkite-analytics).
 
 ## 👩‍💻 Contributing
 

--- a/cypress/reporter.js
+++ b/cypress/reporter.js
@@ -1,10 +1,10 @@
-const MochaBuildkiteAnalyticsReporter = require('../mocha/reporter')
+const MochaBuildkiteTestEngineReporter = require('../mocha/reporter')
 const failureExpanded = require('../util/failureExpanded')
 
 // Cypress uses mocha under the hood for assertions, so there is some overlap
 // between this reporter and the mocha reporter. They differ in how they
 // report errors.
-class CypressBuildkiteAnalyticsReporter extends MochaBuildkiteAnalyticsReporter {
+class CypressBuildkiteTestEngineReporter extends MochaBuildkiteTestEngineReporter {
   constructor(runner, options) {
     super(runner, options)
   }
@@ -15,13 +15,13 @@ class CypressBuildkiteAnalyticsReporter extends MochaBuildkiteAnalyticsReporter 
     const { failureReason, failureExpanded } = this.getFailureReason(test.err)
 
     const result = {
-      'id': test.testAnalyticsId,
+      'id': test.testEngineId,
       'name': test.title,
       'scope': this.scope(test),
       'identifier': test.fullTitle(),
       'file_name': prefixedTestPath,
       'location': prefixedTestPath,
-      'result': this.analyticsResult(test.state),
+      'result': this.testEngineResult(test.state),
       'failure_reason': failureReason,
       'failure_expanded': failureExpanded,
       'history': {
@@ -50,4 +50,4 @@ class CypressBuildkiteAnalyticsReporter extends MochaBuildkiteAnalyticsReporter 
   }
 }
 
-module.exports = CypressBuildkiteAnalyticsReporter
+module.exports = CypressBuildkiteTestEngineReporter

--- a/e2e/cypress.test.js
+++ b/e2e/cypress.test.js
@@ -20,9 +20,9 @@ describe('examples/cypress', () => {
     test('it uses the correct token', (done) => {
       exec('npm test -- --config-file cypress.config.token.js',
         { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
-          expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+          expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-          const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+          const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
           const json = JSON.parse(jsonMatch[1])["headers"]
 
           expect(json).toHaveProperty("Authorization", 'Token token="abc"')
@@ -35,9 +35,9 @@ describe('examples/cypress', () => {
   describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
     test('it uses the correct token', (done) => {
       exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
@@ -49,9 +49,9 @@ describe('examples/cypress', () => {
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON
@@ -84,16 +84,16 @@ describe('examples/cypress', () => {
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
 
-      expect(stdout).toMatch(/Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Engine .* response/m)
       done()
     })
   }, DEFAULT_TIMEOUT)
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON

--- a/e2e/jasmine.test.js
+++ b/e2e/jasmine.test.js
@@ -18,9 +18,9 @@ describe('examples/jasmine', () => {
   describe('when token is defined through reporter options', () => {
     test('it uses the correct token', (done) => {
       exec('npm test spec/token.spec.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="abc"')
@@ -33,9 +33,9 @@ describe('examples/jasmine', () => {
   describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
     test('it uses the correct token', (done) => {
       exec('npm test spec/example.spec.js', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
@@ -47,9 +47,9 @@ describe('examples/jasmine', () => {
 
   test('it posts the correct JSON', (done) => {
     exec('npm test spec/example.spec.js', { cwd, env }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON
@@ -92,9 +92,9 @@ describe('examples/jasmine', () => {
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test spec/example.spec.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON

--- a/e2e/jest.test.js
+++ b/e2e/jest.test.js
@@ -17,9 +17,9 @@ describe('examples/jest', () => {
   describe('when token is defined through reporter options', () => {
     test('it uses the correct token', (done) => {
       exec('jest --config token.config.js', { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="abc"')
@@ -32,9 +32,9 @@ describe('examples/jest', () => {
   describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
     test('it uses the correct token', (done) => {
       exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
@@ -54,9 +54,9 @@ describe('examples/jest', () => {
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON
@@ -98,9 +98,9 @@ describe('examples/jest', () => {
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON

--- a/e2e/mocha.test.js
+++ b/e2e/mocha.test.js
@@ -18,9 +18,9 @@ describe('examples/mocha', () => {
     test('it uses the correct token', (done) => {
       exec('mocha --reporter mocha-multi-reporters --reporter-options configFile=token-config.json',
         { cwd, env: { ...env, BUILDKITE_ANALYTICS_TOKEN: undefined } }, (error, stdout, stderr) => {
-          expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+          expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-          const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+          const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
           const json = JSON.parse(jsonMatch[1])["headers"]
 
           expect(json).toHaveProperty("Authorization", 'Token token="abc"')
@@ -33,9 +33,9 @@ describe('examples/mocha', () => {
   describe('when token is defined through BUILDKITE_ANALYTICS_TOKEN', () => {
     test('it uses the correct token', (done) => {
       exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+        expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-        const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+        const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
         const json = JSON.parse(jsonMatch[1])["headers"]
 
         expect(json).toHaveProperty("Authorization", 'Token token="xyz"')
@@ -54,9 +54,9 @@ describe('examples/mocha', () => {
 
   test('it posts the correct JSON', (done) => {
     exec('npm test', { cwd, env }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON
@@ -86,16 +86,16 @@ describe('examples/mocha', () => {
       expect(json.data[1].failure_reason).toMatch('AssertionError [ERR_ASSERTION]: 41 == 42')
       expect(json).toHaveProperty("data[1].failure_expanded[0].expanded")
       expect(json).toHaveProperty("data[1].failure_expanded[0].backtrace")
-      expect(stdout).toMatch(/Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Engine .* response/m)
 
       done()
     })
   }, 10000) // 10s timeout
 
   describe('when --exit option is enabled', () => {
-    test('it sends the JSON to Buildkite Test Analytics', (done) => {
+    test('it sends the JSON to Buildkite Test Engine', (done) => {
       exec('npm test -- --exit', { cwd, env }, (error, stdout, stderr) => {
-        expect(stdout).toMatch(/Test Analytics .* response/m)
+        expect(stdout).toMatch(/Test Engine .* response/m)
         done()
       })
     })
@@ -103,9 +103,9 @@ describe('examples/mocha', () => {
 
   test('it supports test location prefixes for monorepos', (done) => {
     exec('npm test', { cwd, env: { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" } }, (error, stdout, stderr) => {
-      expect(stdout).toMatch(/.*Test Analytics Sending: ({.*})/m);
+      expect(stdout).toMatch(/.*Test Engine Sending: ({.*})/m);
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const json = JSON.parse(jsonMatch[1])["data"]
 
       // Uncomment to view the JSON

--- a/e2e/playwright.test.js
+++ b/e2e/playwright.test.js
@@ -18,7 +18,7 @@ const runPlaywright = (args, env) => {
 }
 
 const expectOutputToHaveToken = (stdout, expectation) => {
-  const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+  const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
   const headers = JSON.parse(jsonMatch[1])["headers"]
 
   expect(headers).toHaveProperty("Authorization", `Token token="${expectation}"`)
@@ -50,7 +50,7 @@ describe('examples/playwright', () => {
   test('it posts the correct JSON', async () => {
     const stdout = await runPlaywright([], env)
 
-    const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+    const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
     const data = JSON.parse(jsonMatch[1])["data"]
 
     expect(data).toHaveProperty("format", "json")
@@ -80,20 +80,20 @@ describe('examples/playwright', () => {
         expanded: expect.arrayContaining(['Expected string: "Hello, World!"', 'Received string: ""'])
       })
     ]))
-    expect(stdout).toMatch(/Test Analytics .* response/m)
+    expect(stdout).toMatch(/Test Engine .* response/m)
   }, TIMEOUT);
 
   describe('when --retries option is used', () => {
     test("it posts all retried executions", async () => {
       const stdout = await runPlaywright(["--retries=1"], env)
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const data = JSON.parse(jsonMatch[1])["data"]["data"];
 
       const retriedTest = data.filter(test => test.name === "says hello")
       expect(retriedTest.length).toEqual(2)
       expect(retriedTest.map(test => test.result)).toEqual(["failed", "passed"])
-      expect(stdout).toMatch(/Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Engine .* response/m)
     }, TIMEOUT)
   })
 
@@ -101,7 +101,7 @@ describe('examples/playwright', () => {
     test("it posts the failures", async () => {
       const stdout = await runPlaywright(["--timeout=1"], env)
 
-      const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+      const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
       const data = JSON.parse(jsonMatch[1])["data"];
 
       expect(data).toHaveProperty("format", "json")
@@ -135,14 +135,14 @@ describe('examples/playwright', () => {
           expanded: expect.arrayContaining(["Test timeout of 1ms exceeded."])
         })
       ]))
-      expect(stdout).toMatch(/Test Analytics .* response/m)
+      expect(stdout).toMatch(/Test Engine .* response/m)
     }, TIMEOUT)
   })
 
   test('it supports test location prefixes for monorepos', async () => {
     const stdout = await runPlaywright([], { ...env, BUILDKITE_ANALYTICS_LOCATION_PREFIX: "some-sub-dir/" })
 
-    const jsonMatch = stdout.match(/.*Test Analytics Sending: ({.*})/m)
+    const jsonMatch = stdout.match(/.*Test Engine Sending: ({.*})/m)
     const data = JSON.parse(jsonMatch[1])["data"]
 
     expect(data).toHaveProperty("run_env.location_prefix", "some-sub-dir/")

--- a/examples/jest/jest.config.js
+++ b/examples/jest/jest.config.js
@@ -1,5 +1,5 @@
 const config = {
-  // Send results to Test Analytics
+  // Send results to Test Engine
   reporters: [
     'default',
     ['buildkite-test-collector/jest/reporter', {
@@ -7,7 +7,7 @@ const config = {
     }]
   ],
 
-  // Enable column + line capture for Test Analytics
+  // Enable column + line capture for Test Engine
   testLocationInResults: true
 };
 

--- a/examples/jest/token.config.js
+++ b/examples/jest/token.config.js
@@ -1,11 +1,11 @@
 const config = {
-  // Send results to Test Analytics
+  // Send results to Test Engine
   reporters: [
     'default',
     ['buildkite-test-collector/jest/reporter', { token: process.env.BUILDKITE_ANALYTICS_JEST_TOKEN }]
   ],
 
-  // Enable column + line capture for Test Analytics
+  // Enable column + line capture for Test Engine
   testLocationInResults: true
 };
 

--- a/jasmine/reporter.js
+++ b/jasmine/reporter.js
@@ -36,7 +36,7 @@ jasmine.getEnv().it = itFactory(jasmine.getEnv().it);
 jasmine.getEnv().xit = itFactory(jasmine.getEnv().xit);
 jasmine.getEnv().fit = itFactory(jasmine.getEnv().fit);
 
-class JasmineBuildkiteAnalyticsReporter {
+class JasmineBuildkiteTestEngineReporter {
   constructor(config = { cwd: process.cwd() }, options) {
     this.config = config
     this._options = options
@@ -69,7 +69,7 @@ class JasmineBuildkiteAnalyticsReporter {
       'name': result.description,
       'location': result.location ? `${prefixedTestPath}:${result.location.line}` : null,
       'file_name': prefixedTestPath,
-      'result': this.analyticsResult(result),
+      'result': this.testEngineResult(result),
       'failure_reason': (result.failedExpectations[0] || {}).message,
       'failure_expanded': failureExpanded(result.failedExpectations),
       'history': result.properties.tracer.history(),
@@ -80,14 +80,14 @@ class JasmineBuildkiteAnalyticsReporter {
     return uploadTestResults(this._testEnv, this._tags, this._testResults, this._options, done)
   }
 
-  analyticsResult(testResult) {
+  testEngineResult(testResult) {
     // Jasmine test statuses:
     // - passed
     // - pending
     // - failed
     // - disabled
     //
-    // Buildkite Test Analytics execution results:
+    // Buildkite Test Engine execution results:
     // - passed
     // - failed
     // - pending
@@ -102,4 +102,4 @@ class JasmineBuildkiteAnalyticsReporter {
   }
 }
 
-module.exports = JasmineBuildkiteAnalyticsReporter
+module.exports = JasmineBuildkiteTestEngineReporter

--- a/jest/reporter.js
+++ b/jest/reporter.js
@@ -3,7 +3,7 @@ const CI = require('../util/ci')
 const uploadTestResults = require('../util/uploadTestResults')
 const Paths = require('../util/paths')
 
-class JestBuildkiteAnalyticsReporter {
+class JestBuildkiteTestEngineReporter {
   constructor(globalConfig, options) {
     this._globalConfig = globalConfig
     this._options = options
@@ -42,9 +42,9 @@ class JestBuildkiteAnalyticsReporter {
         'name': result.title,
         'location': result.location ? `${prefixedTestPath}:${result.location.line}` : null,
         'file_name': prefixedTestPath,
-        'result': this.analyticsResult(result),
-        'failure_reason': this.analyticsFailureReason(result),
-        'failure_expanded': this.analyticsFailureExpanded(result),
+        'result': this.testEngineResult(result),
+        'failure_reason': this.testEngineFailureReason(result),
+        'failure_expanded': this.testEngineFailureExpanded(result),
         'history': {
           'section': 'top',
           'start_at': testResult.perfStats.start,
@@ -57,14 +57,14 @@ class JestBuildkiteAnalyticsReporter {
   }
 
 
-  analyticsResult(testResult) {
+  testEngineResult(testResult) {
     // Jest test statuses:
     // - passed
     // - pending
     // - failed
     // - todo
     //
-    // Buildkite Test Analytics execution results:
+    // Buildkite Test Engine execution results:
     // - passed
     // - failed
     // - pending
@@ -78,24 +78,24 @@ class JestBuildkiteAnalyticsReporter {
     }[testResult.status]
   }
 
-  analyticsFailureMessages(testResult) {
+  testEngineFailureMessages(testResult) {
     if (testResult.status !== 'failed') return []
 
     // Strip ANSI color codes from messages and split each line
     return testResult.failureMessages.join(' ').replace(/\u001b[^m]*?m/g,'').split("\n")
   }
-  
-  analyticsFailureReason(testResult) {
-    return this.analyticsFailureMessages(testResult)[0]
+
+  testEngineFailureReason(testResult) {
+    return this.testEngineFailureMessages(testResult)[0]
   }
 
-  analyticsFailureExpanded(testResult) {
+  testEngineFailureExpanded(testResult) {
     return [
       { 
-        expanded: this.analyticsFailureMessages(testResult).splice(1)
+        expanded: this.testEngineFailureMessages(testResult).splice(1)
       }
     ]
   }
 }
 
-module.exports = JestBuildkiteAnalyticsReporter
+module.exports = JestBuildkiteTestEngineReporter

--- a/mocha/reporter.js
+++ b/mocha/reporter.js
@@ -17,7 +17,7 @@ const {
   STATE_FAILED,
 } = Runnable.constants
 
-class MochaBuildkiteAnalyticsReporter {
+class MochaBuildkiteTestEngineReporter {
   constructor(runner, options) {
     this._options = { token: process.env[`${options.reporterOptions.token_name}`]}
     this._testResults = []
@@ -35,7 +35,7 @@ class MochaBuildkiteAnalyticsReporter {
   }
 
   testStarted(test) {
-    test.testAnalyticsId = uuidv4()
+    test.testEngineId = uuidv4()
     test.startAt = performance.now() / 1000
   }
 
@@ -44,12 +44,12 @@ class MochaBuildkiteAnalyticsReporter {
     const prefixedTestPath = this._paths.prefixTestPath(this.getRootParentFile(test))
 
     this._testResults.push({
-      'id': test.testAnalyticsId,
+      'id': test.testEngineId,
       'name': test.title,
       'scope': this.scope(test),
       'file_name': prefixedTestPath,
       'location': prefixedTestPath,
-      'result': this.analyticsResult(test.state),
+      'result': this.testEngineResult(test.state),
       'failure_reason': failureReason,
       'failure_expanded': failureExpanded(test.err == undefined ? [] : (test.err.multiple || [test.err])),
       'history': {
@@ -70,13 +70,13 @@ class MochaBuildkiteAnalyticsReporter {
     uploadTestResults(this._testEnv, this._tags, this._testResults, this._options, exit)
   }
 
-  analyticsResult(state) {
+  testEngineResult(state) {
     // Mocha test statuses:
     // - passed
     // - failed
     // - pending
     //
-    // Buildkite Test Analytics execution results:
+    // Buildkite Test Engine execution results:
     // - passed
     // - failed
     // - pending
@@ -110,4 +110,4 @@ class MochaBuildkiteAnalyticsReporter {
   }
 }
 
-module.exports = MochaBuildkiteAnalyticsReporter
+module.exports = MochaBuildkiteTestEngineReporter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buildkite-test-collector",
-  "description": "Buildkite Test Analytics collectors for JavaScript test frameworks",
+  "description": "Buildkite Test Engine collectors for JavaScript test frameworks",
   "keywords": [
     "javascript",
     "buildkite",
@@ -8,7 +8,7 @@
     "buildkite-test-collector"
   ],
   "version": "1.8.0",
-  "homepage": "https://buildkite.com/test-analytics",
+  "homepage": "https://buildkite.com/platform/test-engine",
   "bugs": "https://github.com/buildkite/test-collector-javascript/issues",
   "license": "MIT",
   "files": [

--- a/playwright/reporter.js
+++ b/playwright/reporter.js
@@ -15,11 +15,11 @@ const Paths = require('../util/paths')
  */
 
 /**
- * A playwright reporter that uploads test results to Buildkite Test Analytics
+ * A playwright reporter that uploads test results to Buildkite Test Engine
  *
  * @implements {import('@playwright/test/reporter').Reporter}
  */
-class PlaywrightBuildkiteAnalyticsReporter {
+class PlaywrightBuildkiteTestEngineReporter {
 
   constructor(options) {
     this._testResults = [];
@@ -55,9 +55,9 @@ class PlaywrightBuildkiteAnalyticsReporter {
       'scope': scope,
       'location': location,
       'file_name': fileName,
-      'result': this.analyticsResult(testResult.status),
-      'failure_reason': this.analyticsFailureReason(testResult),
-      'failure_expanded': this.analyticsFailureExpanded(testResult),
+      'result': this.testEngineResult(testResult.status),
+      'failure_reason': this.testEngineFailureReason(testResult),
+      'failure_expanded': this.testEngineFailureExpanded(testResult),
       'history': {
         'section': 'top',
         'start_at': testResult.startTime.getTime(),
@@ -66,7 +66,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
     });
   }
 
-  analyticsResult(status) {
+  testEngineResult(status) {
     // Playwright test statuses:
     // - failed
     // - interrupted
@@ -74,7 +74,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
     // - skipped
     // - timedOut
     //
-    // Buildkite Test Analytics execution results:
+    // Buildkite Test Engine execution results:
     // - failed
     // - passed
     // - pending
@@ -93,7 +93,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
    *
    * @param {TestResult} testResult
    */
-  analyticsFailureReason(testResult) {
+  testEngineFailureReason(testResult) {
     if (testResult.error == undefined) return "";
 
     const reason = stripAnsi(testResult.error.message).split("\n")[0];
@@ -105,7 +105,7 @@ class PlaywrightBuildkiteAnalyticsReporter {
    *
    * @param {TestResult} testResult
    */
-  analyticsFailureExpanded(testResult) {
+  testEngineFailureExpanded(testResult) {
     let expandedErrors = [];
 
     if (testResult.errors) {
@@ -129,4 +129,4 @@ class PlaywrightBuildkiteAnalyticsReporter {
   }
 }
 
-module.exports = PlaywrightBuildkiteAnalyticsReporter
+module.exports = PlaywrightBuildkiteTestEngineReporter

--- a/util/uploadTestResults.js
+++ b/util/uploadTestResults.js
@@ -26,13 +26,13 @@ const uploadTestResults = (env, tags, results, options, done) => {
 
   if (Debug.enabled()) {
     axios.interceptors.request.use(function (config) {
-      Debug.log(`Test Analytics Sending: ${JSON.stringify(config)}`);
+      Debug.log(`Test Engine Sending: ${JSON.stringify(config)}`);
       return config;
     }, function (error) {
       if (error.response) {
-        Debug.log(`Test Analytics request error: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+        Debug.log(`Test Engine request error: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
       } else {
-        Debug.log(`Test Analytics request error: ${error.message}`)
+        Debug.log(`Test Engine request error: ${error.message}`)
       }
       // Do something with request error
       return Promise.reject(error);
@@ -43,13 +43,13 @@ const uploadTestResults = (env, tags, results, options, done) => {
   axios.interceptors.response.use(function (response) {
     // Any status code that lie within the range of 2xx cause this function to trigger
     // Do something with response data
-    Debug.log(`Test Analytics success response ${JSON.stringify(response.data)}`);
+    Debug.log(`Test Engine success response ${JSON.stringify(response.data)}`);
     return response;
   }, function (error) {
     if (error.response) {
-      console.log(`⚠️ Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+      console.log(`⚠️ Test Engine error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
     } else {
-      console.log(`⚠️ Test Analytics error: ${error.message}`)
+      console.log(`⚠️ Test Engine error: ${error.message}`)
     }
     return Promise.reject(error);
   });


### PR DESCRIPTION
### Description

Buildkite Test Analytics has been renamed to Buildkite Test Engine. This PR migrates a variety of references to Test Analytics over to the new product name of Test Engine.

It _doesn't_ migrate anything customer-facing like environment variables. Only internal method names and text.